### PR TITLE
Gate construction on a stored [[Construct]] capability

### DIFF
--- a/src/arc.gleam
+++ b/src/arc.gleam
@@ -95,7 +95,7 @@ fn inspect_object(h: Heap, ref: Ref, depth: Int, seen: set.Set(Int)) -> String {
             ArrayObject(length:) ->
               inspect_array(h, elements, length, depth, seen)
             FunctionObject(..) -> inspect_function(properties)
-            NativeFunction(_) -> inspect_function(properties)
+            NativeFunction(..) -> inspect_function(properties)
             OrdinaryObject ->
               inspect_tagged_object(
                 h,

--- a/src/arc/vm/builtins/common.gleam
+++ b/src/arc/vm/builtins/common.gleam
@@ -195,7 +195,10 @@ fn alloc_native_fn_slot(
     heap.alloc(
       h,
       ObjectSlot(
-        kind: NativeFunction(slot),
+        // Ordinary built-ins (methods, standalone functions, host fns) are
+        // not constructors. The constructor intrinsics take a separate path
+        // (init_type / init_type_on), and bind copies its target's bit.
+        kind: NativeFunction(slot, constructible: False),
         properties: named_props([
           #("name", fn_name_property(name)),
           #("length", fn_length_property(arity)),
@@ -410,7 +413,8 @@ pub fn init_type(
     heap.alloc(
       h,
       ObjectSlot(
-        kind: NativeFunction(ctor_fn(proto_ref)),
+        // init_type creates a constructor intrinsic — it has [[Construct]].
+        kind: NativeFunction(ctor_fn(proto_ref), constructible: True),
         properties: named_props(ctor_properties(
           proto_ref,
           name,
@@ -496,13 +500,16 @@ pub fn init_type_on(
   name: String,
   arity: Int,
   ctor_props: List(#(String, Property)),
+  // Whether the created function has [[Construct]]. True for real constructors
+  // (Object, Function); False for abstract/non-constructor types (Iterator).
+  constructible: Bool,
 ) -> #(Heap(ctx), BuiltinType) {
   // Allocate constructor — proto ref already known
   let #(h, ctor_ref) =
     heap.alloc(
       h,
       ObjectSlot(
-        kind: NativeFunction(ctor_fn(proto)),
+        kind: NativeFunction(ctor_fn(proto), constructible:),
         properties: named_props(ctor_properties(proto, name, arity, ctor_props)),
         elements: elements.new(),
         prototype: Some(function_proto),

--- a/src/arc/vm/builtins/function.gleam
+++ b/src/arc/vm/builtins/function.gleam
@@ -36,5 +36,6 @@ pub fn init(h: Heap(ctx), object_proto: Ref) -> #(Heap(ctx), BuiltinType) {
     "Function",
     1,
     [],
+    True,
   )
 }

--- a/src/arc/vm/builtins/helpers.gleam
+++ b/src/arc/vm/builtins/helpers.gleam
@@ -24,7 +24,7 @@ pub fn is_callable(h: Heap(ctx), val: JsValue) -> Bool {
       case heap.read(h, ref) {
         // Step 2: If argument has a [[Call]] internal method, return true.
         Some(ObjectSlot(kind: value.FunctionObject(..), ..)) -> True
-        Some(ObjectSlot(kind: value.NativeFunction(_), ..)) -> True
+        Some(ObjectSlot(kind: value.NativeFunction(..), ..)) -> True
         // Step 3: Return false.
         _ -> False
       }

--- a/src/arc/vm/builtins/iterator.gleam
+++ b/src/arc/vm/builtins/iterator.gleam
@@ -76,6 +76,11 @@ pub fn init(
       "Iterator",
       0,
       ctor_props,
+      // §27.1.3.1: Iterator is an abstract constructor — it HAS [[Construct]]
+      // (IsConstructor(Iterator) is true and it's subclassable), but `new
+      // Iterator()` directly throws. The IteratorConstructor native enforces
+      // that: it returns `this` for a subclass super() call, throws otherwise.
+      True,
     )
 
   // §27.1.3.2 Iterator.prototype.constructor and §27.1.3.13 [@@toStringTag] are

--- a/src/arc/vm/builtins/object.gleam
+++ b/src/arc/vm/builtins/object.gleam
@@ -150,6 +150,7 @@ pub fn init(
     "Object",
     1,
     static_methods,
+    True,
   )
 }
 
@@ -1145,7 +1146,7 @@ fn object_tag(heap: Heap, ref: Ref) -> String {
           case kind {
             ArrayObject(_) -> "Array"
             value.ArgumentsObject(_) -> "Arguments"
-            FunctionObject(..) | NativeFunction(_) -> "Function"
+            FunctionObject(..) | NativeFunction(..) -> "Function"
             PromiseObject(_) -> "Promise"
             GeneratorObject(_) -> "Generator"
             value.AsyncGeneratorObject(_) -> "AsyncGenerator"

--- a/src/arc/vm/builtins/promise.gleam
+++ b/src/arc/vm/builtins/promise.gleam
@@ -149,6 +149,7 @@ pub fn create_resolving_functions(
             data_ref:,
             already_resolved_ref:,
           )),
+          constructible: False,
         ),
         properties: common.named_props([
           #("name", common.fn_name_property("")),
@@ -172,6 +173,7 @@ pub fn create_resolving_functions(
             data_ref:,
             already_resolved_ref:,
           )),
+          constructible: False,
         ),
         properties: common.named_props([
           #("name", common.fn_name_property("")),

--- a/src/arc/vm/builtins/reflect.gleam
+++ b/src/arc/vm/builtins/reflect.gleam
@@ -160,21 +160,35 @@ fn reflect_apply(
 ///   4. Let args be ? CreateListFromArrayLike(argumentsList).
 ///   5. Return ? Construct(target, args, newTarget).
 ///
-/// TODO: newTarget (third arg) not yet wired — needs separate plumbing through
-/// do_construct to override the prototype source.
+/// TODO: newTarget (third arg) not yet fully wired — needs separate plumbing
+/// through do_construct to override the prototype source. The IsConstructor
+/// check for newTarget IS implemented.
 fn reflect_construct(
   args: List(JsValue),
   state: State,
 ) -> #(State, Result(JsValue, JsValue)) {
-  let #(target, args_list) = case args {
-    [t, a, ..] -> #(t, a)
-    [t] -> #(t, JsUndefined)
-    [] -> #(JsUndefined, JsUndefined)
+  let #(target, args_list, new_target) = case args {
+    [t, a, nt, ..] -> #(t, a, Some(nt))
+    [t, a] -> #(t, a, None)
+    [t] -> #(t, JsUndefined, None)
+    [] -> #(JsUndefined, JsUndefined, None)
   }
+  // Step 1: If IsConstructor(target) is false, throw a TypeError exception.
+  use <- bool.lazy_guard(!object.is_constructor(state.heap, target), fn() {
+    state.type_error(state, "target is not a constructor")
+  })
+  // Step 3: If newTarget is present and IsConstructor(newTarget) is false,
+  // throw a TypeError exception.
+  let new_target_valid = case new_target {
+    Some(nt) -> object.is_constructor(state.heap, nt)
+    None -> True
+  }
+  use <- bool.lazy_guard(!new_target_valid, fn() {
+    state.type_error(state, "newTarget is not a constructor")
+  })
   // Step 4: Let args be ? CreateListFromArrayLike(argumentsList).
   use ctor_args, state <- require_array_like(state, args_list)
-  // Steps 1, 5: state.construct validates target is an object and runs
-  // [[Construct]]. Non-constructor objects throw inside do_construct.
+  // Step 5: Return ? Construct(target, args, newTarget).
   use result, state <- state.try_op(state.construct(state, target, ctor_args))
   #(state, Ok(result))
 }

--- a/src/arc/vm/builtins/symbol.gleam
+++ b/src/arc/vm/builtins/symbol.gleam
@@ -26,7 +26,7 @@ pub fn init(
     heap.alloc(
       h,
       ObjectSlot(
-        kind: NativeFunction(Call(SymbolFor)),
+        kind: NativeFunction(Call(SymbolFor), constructible: False),
         properties: common.named_props([
           #("name", common.fn_name_property("for")),
           #("length", common.fn_length_property(1)),
@@ -41,7 +41,7 @@ pub fn init(
     heap.alloc(
       h,
       ObjectSlot(
-        kind: NativeFunction(Call(SymbolKeyFor)),
+        kind: NativeFunction(Call(SymbolKeyFor), constructible: False),
         properties: common.named_props([
           #("name", common.fn_name_property("keyFor")),
           #("length", common.fn_length_property(1)),
@@ -57,7 +57,10 @@ pub fn init(
     heap.alloc(
       h,
       ObjectSlot(
-        kind: NativeFunction(Call(SymbolConstructor)),
+        // §20.4.1: Symbol HAS [[Construct]] (it may appear in an `extends`
+        // clause), so IsConstructor(Symbol) is true — but invoking it as a
+        // constructor always throws (do_construct / super() handle that).
+        kind: NativeFunction(Call(SymbolConstructor), constructible: True),
         properties: common.named_props([
           #("name", common.fn_name_property("Symbol")),
           #("length", common.fn_length_property(0)),

--- a/src/arc/vm/exec/async_generators.gleam
+++ b/src/arc/vm/exec/async_generators.gleam
@@ -701,6 +701,7 @@ fn alloc_resume(
     h,
     NativeFunction(
       value.Call(value.AsyncGeneratorResume(data_ref:, is_reject:, kind:)),
+      constructible: False,
     ),
     function_proto,
   )

--- a/src/arc/vm/exec/call.gleam
+++ b/src/arc/vm/exec/call.gleam
@@ -561,6 +561,7 @@ fn async_setup_await(
       h,
       NativeFunction(
         value.Call(value.AsyncResume(async_data_ref:, is_reject: False)),
+        constructible: False,
       ),
       builtins.function.prototype,
     )
@@ -569,6 +570,7 @@ fn async_setup_await(
       h,
       NativeFunction(
         value.Call(value.AsyncResume(async_data_ref:, is_reject: True)),
+        constructible: False,
       ),
       builtins.function.prototype,
     )
@@ -861,6 +863,12 @@ pub fn call_native(
                     bound_this: this_arg,
                     bound_args:,
                   )),
+                  // §10.4.1.3 step 6: the bound function has [[Construct]] iff
+                  // its target does. Copy the target's bit at bind time.
+                  constructible: object.is_constructor(
+                    state.heap,
+                    JsObject(target_ref),
+                  ),
                 ),
                 properties: dict.from_list([
                   #(Named("name"), common.fn_name_property(name)),
@@ -1325,6 +1333,16 @@ pub fn do_construct(
   dispatch_fn: DispatchNativeFn,
 ) -> Result(State, #(StepResult, JsValue, State)) {
   case heap.read(state.heap, ctor_ref) {
+    Some(ObjectSlot(kind: FunctionObject(func_template:, ..), ..))
+      if func_template.is_arrow
+      || func_template.is_generator
+      || func_template.is_async
+    ->
+      state.throw_type_error(
+        state,
+        object.inspect(JsObject(ctor_ref), state.heap)
+          <> " is not a constructor",
+      )
     Some(ObjectSlot(
       kind: FunctionObject(func_template:, env: env_ref),
       properties:,
@@ -1385,17 +1403,19 @@ pub fn do_construct(
         }
       }
     }
-    // Bound function used as constructor: resolve target, prepend args
+    // Bound function used as constructor (§10.4.1.2): prepend the bound args
+    // and recurse on the target through the same construct path, so the
+    // target's [[Construct]] — derived classes, primitive wrappers, and
+    // chained bound functions — is handled uniformly by do_construct itself.
     Some(ObjectSlot(
-      kind: NativeFunction(value.Call(value.BoundFunction(
-        target:,
-        bound_args:,
+      kind: NativeFunction(
+        value.Call(value.BoundFunction(target:, bound_args:, ..)),
         ..,
-      ))),
+      ),
       ..,
     )) -> {
       let final_args = list.append(bound_args, args)
-      construct_value(
+      do_construct(
         state,
         target,
         final_args,
@@ -1411,7 +1431,7 @@ pub fn do_construct(
     // is defined, so a Symbol arg flows into ToString and throws.
     // TODO(Deviation): ignores NewTarget for prototype (no subclass support).
     Some(ObjectSlot(
-      kind: NativeFunction(value.Call(value.StringConstructor)),
+      kind: NativeFunction(value.Call(value.StringConstructor), ..),
       ..,
     )) -> {
       let coerced = case args {
@@ -1434,9 +1454,10 @@ pub fn do_construct(
     // with [[NumberData]] = n.
     // TODO(Deviation): ignores NewTarget for prototype (no subclass support).
     Some(ObjectSlot(
-      kind: NativeFunction(value.Dispatch(value.NumberNative(
-        value.NumberConstructor,
-      ))),
+      kind: NativeFunction(
+        value.Dispatch(value.NumberNative(value.NumberConstructor)),
+        ..,
+      ),
       ..,
     )) -> {
       let n = case args {
@@ -1454,9 +1475,10 @@ pub fn do_construct(
     // wrapper object with [[BooleanData]] = b.
     // TODO(Deviation): ignores NewTarget for prototype (no subclass support).
     Some(ObjectSlot(
-      kind: NativeFunction(value.Dispatch(value.BooleanNative(
-        value.BooleanConstructor,
-      ))),
+      kind: NativeFunction(
+        value.Dispatch(value.BooleanNative(value.BooleanConstructor)),
+        ..,
+      ),
       ..,
     )) -> {
       let b = case args {
@@ -1470,109 +1492,36 @@ pub fn do_construct(
         state.builtins.boolean.prototype,
       )
     }
-    Some(ObjectSlot(kind: NativeFunction(native), ..)) ->
-      call_native(
-        state,
-        native,
-        args,
-        rest_stack,
-        JsUndefined,
-        execute_inner,
-        unwind_to_catch,
-        dispatch_fn,
-      )
+    // §20.4.1.1: Symbol has [[Construct]] (so IsConstructor is true and it can
+    // appear in `extends`), but invoking it as a constructor always throws.
+    Some(ObjectSlot(
+      kind: NativeFunction(value.Call(value.SymbolConstructor), ..),
+      ..,
+    )) -> state.throw_type_error(state, "Symbol is not a constructor")
+    Some(ObjectSlot(kind: NativeFunction(native, ..), ..)) ->
+      case object.is_constructor(state.heap, JsObject(ctor_ref)) {
+        True ->
+          call_native(
+            state,
+            native,
+            args,
+            rest_stack,
+            JsUndefined,
+            execute_inner,
+            unwind_to_catch,
+            dispatch_fn,
+          )
+        False ->
+          state.throw_type_error(
+            state,
+            object.inspect(JsObject(ctor_ref), state.heap)
+              <> " is not a constructor",
+          )
+      }
     _ ->
       state.throw_type_error(
         state,
         object.inspect(JsObject(ctor_ref), state.heap)
-          <> " is not a constructor",
-      )
-  }
-}
-
-/// Construct a new object using the target function ref.
-/// Used by CallConstructor when the constructor is a bound function.
-pub fn construct_value(
-  state: State,
-  target_ref: Ref,
-  args: List(JsValue),
-  rest_stack: List(JsValue),
-  execute_inner: ExecuteInnerFn,
-  unwind_to_catch: UnwindToCatchFn,
-  dispatch_fn: DispatchNativeFn,
-) -> Result(State, #(StepResult, JsValue, State)) {
-  case heap.read(state.heap, target_ref) {
-    Some(ObjectSlot(
-      kind: FunctionObject(func_template:, env: env_ref),
-      properties:,
-      ..,
-    )) -> {
-      let proto = case dict.get(properties, Named("prototype")) {
-        Ok(DataProperty(value: JsObject(proto_ref), ..)) -> Some(proto_ref)
-        _ -> Some(state.builtins.object.prototype)
-      }
-      let #(h, new_obj_ref) =
-        heap.alloc(
-          state.heap,
-          ObjectSlot(
-            kind: OrdinaryObject,
-            properties: dict.new(),
-            elements: elements.new(),
-            prototype: proto,
-            symbol_properties: [],
-            extensible: True,
-          ),
-        )
-      let new_obj = JsObject(new_obj_ref)
-      call_function(
-        State(..state, heap: h),
-        target_ref,
-        env_ref,
-        func_template,
-        args,
-        rest_stack,
-        new_obj,
-        Some(new_obj),
-        None,
-        execute_inner,
-        unwind_to_catch,
-      )
-    }
-    // Chained bound function: resolve further
-    Some(ObjectSlot(
-      kind: NativeFunction(value.Call(value.BoundFunction(
-        target:,
-        bound_args:,
-        ..,
-      ))),
-      ..,
-    )) -> {
-      let final_args = list.append(bound_args, args)
-      construct_value(
-        state,
-        target,
-        final_args,
-        rest_stack,
-        execute_inner,
-        unwind_to_catch,
-        dispatch_fn,
-      )
-    }
-    Some(ObjectSlot(kind: NativeFunction(native), ..)) ->
-      call_native(
-        state,
-        native,
-        args,
-        rest_stack,
-        JsUndefined,
-        execute_inner,
-        unwind_to_catch,
-        dispatch_fn,
-      )
-    _ ->
-      state.throw_type_error(
-        state,
-        object.inspect(JsObject(target_ref), state.heap)
           <> " is not a constructor",
       )
   }
@@ -1606,7 +1555,7 @@ pub fn call_value(
             execute_inner,
             unwind_to_catch,
           )
-        Some(ObjectSlot(kind: NativeFunction(native), ..)) ->
+        Some(ObjectSlot(kind: NativeFunction(native, ..), ..)) ->
           call_native(
             state,
             native,
@@ -1832,7 +1781,7 @@ pub fn function_to_string(
           }
           #(state, Ok(JsString("function " <> name <> "() { [native code] }")))
         }
-        Some(ObjectSlot(kind: NativeFunction(_), properties:, ..)) -> {
+        Some(ObjectSlot(kind: NativeFunction(_, ..), properties:, ..)) -> {
           let name =
             dict.get(properties, Named("name"))
             |> result.map(fn(p) {

--- a/src/arc/vm/exec/event_loop.gleam
+++ b/src/arc/vm/exec/event_loop.gleam
@@ -170,7 +170,7 @@ pub fn run_handler_with_this(
             this_val,
             execute_inner,
           )
-        Some(ObjectSlot(kind: NativeFunction(native), ..)) -> {
+        Some(ObjectSlot(kind: NativeFunction(native, ..), ..)) -> {
           // For native functions (like resolve/reject), call directly
           let job_state =
             State(

--- a/src/arc/vm/exec/interpreter.gleam
+++ b/src/arc/vm/exec/interpreter.gleam
@@ -1959,7 +1959,7 @@ fn step(state: State, op: Op) -> Result(State, #(StepResult, JsValue, State)) {
                     None,
                     None,
                   )
-                Some(ObjectSlot(kind: NativeFunction(native), ..)) ->
+                Some(ObjectSlot(kind: NativeFunction(native, ..), ..)) ->
                   call_native(state, native, args, rest_stack, JsUndefined)
                 _ ->
                   state.throw_type_error(
@@ -2005,7 +2005,7 @@ fn step(state: State, op: Op) -> Result(State, #(StepResult, JsValue, State)) {
                     None,
                     None,
                   )
-                Some(ObjectSlot(kind: NativeFunction(native), ..)) ->
+                Some(ObjectSlot(kind: NativeFunction(native, ..), ..)) ->
                   call_native(state, native, args, rest_stack, receiver)
                 _ ->
                   state.throw_type_error(
@@ -2918,11 +2918,10 @@ fn do_call_super_dispatch(
     // [[BoundTargetFunction]] with [[BoundArguments]] prepended; bound `this`
     // is ignored under [[Construct]].
     Some(ObjectSlot(
-      kind: NativeFunction(value.Call(value.BoundFunction(
-        target:,
-        bound_args:,
+      kind: NativeFunction(
+        value.Call(value.BoundFunction(target:, bound_args:, ..)),
         ..,
-      ))),
+      ),
       ..,
     )) ->
       do_call_super_dispatch(
@@ -2934,10 +2933,10 @@ fn do_call_super_dispatch(
       )
     // §20.4.1: Symbol has no [[Construct]]; super() into Symbol must throw.
     Some(ObjectSlot(
-      kind: NativeFunction(value.Call(value.SymbolConstructor)),
+      kind: NativeFunction(value.Call(value.SymbolConstructor), ..),
       ..,
     )) -> state.throw_type_error(state, "Symbol is not a constructor")
-    Some(ObjectSlot(kind: NativeFunction(native), ..)) -> {
+    Some(ObjectSlot(kind: NativeFunction(native, ..), ..)) -> {
       // Built-in parent (Array, Map, Error, …): per spec the result of
       // Construct(func, args, newTarget) becomes `this`. Arc's native ctors
       // don't thread newTarget, so pre-allocate the derived instance and pass

--- a/src/arc/vm/exec/promises.gleam
+++ b/src/arc/vm/exec/promises.gleam
@@ -409,6 +409,7 @@ pub fn call_native_promise_finally(
           state.heap,
           value.NativeFunction(
             value.Call(value.PromiseFinallyFulfill(on_finally:)),
+            constructible: False,
           ),
           state.builtins.function.prototype,
         )
@@ -418,6 +419,7 @@ pub fn call_native_promise_finally(
           h,
           value.NativeFunction(
             value.Call(value.PromiseFinallyReject(on_finally:)),
+            constructible: False,
           ),
           state.builtins.function.prototype,
         )
@@ -505,6 +507,7 @@ fn finally_chain_value(
       state1.heap,
       value.NativeFunction(
         value.Call(value.PromiseFinallyValueThunk(value: captured_value)),
+        constructible: False,
       ),
       state.builtins.function.prototype,
     )
@@ -538,6 +541,7 @@ fn finally_chain_throw(
       state1.heap,
       value.NativeFunction(
         value.Call(value.PromiseFinallyThrower(reason: captured_reason)),
+        constructible: False,
       ),
       state.builtins.function.prototype,
     )
@@ -1537,7 +1541,8 @@ fn alloc_closure(
     heap.alloc(
       h,
       ObjectSlot(
-        kind: NativeFunction(value.Call(native)),
+        // Promise reaction job functions — not constructors.
+        kind: NativeFunction(value.Call(native), constructible: False),
         properties: dict.from_list([
           #(Named("name"), common.fn_name_property("")),
           #(Named("length"), common.fn_length_property(1)),

--- a/src/arc/vm/ops/coerce.gleam
+++ b/src/arc/vm/ops/coerce.gleam
@@ -227,7 +227,7 @@ pub fn js_instanceof(
       case heap.read(state.heap, ctor_ref) {
         // Step 4: IsCallable(target) — we check for function slot kinds.
         Some(ObjectSlot(kind: FunctionObject(..), ..))
-        | Some(ObjectSlot(kind: NativeFunction(_), ..)) -> {
+        | Some(ObjectSlot(kind: NativeFunction(..), ..)) -> {
           // Step 5: OrdinaryHasInstance(target, V) — inlined below.
           // OrdinaryHasInstance step 4: Let P be ? Get(C, "prototype").
           use #(proto_val, state) <- result.try(object.get_value(

--- a/src/arc/vm/ops/object.gleam
+++ b/src/arc/vm/ops/object.gleam
@@ -1498,7 +1498,7 @@ fn inspect_object(
           }
           "[Function: " <> name <> "]"
         }
-        NativeFunction(_) -> {
+        NativeFunction(..) -> {
           let name = case dict.get(properties, Named("name")) {
             Ok(DataProperty(value: JsString(n), ..)) -> n
             _ -> "native"
@@ -1640,5 +1640,34 @@ fn inspect_error_name(heap: Heap, ref: value.Ref) -> String {
         _ -> "Error"
       }
     _ -> "Error"
+  }
+}
+
+/// **IsConstructor(argument)** — ES2024 §7.2.4. Returns True iff `value` is an
+/// object with a [[Construct]] internal method. Single source of truth for
+/// constructibility, shared by the `new` / construct path (exec/call) and
+/// `Reflect.construct` (builtins/reflect).
+pub fn is_constructor(heap: Heap, value: JsValue) -> Bool {
+  case value {
+    JsObject(ref) ->
+      case heap.read(heap, ref) {
+        // ECMAScript function: a constructor unless it's an arrow, generator,
+        // or async function — those lack [[Construct]] (§10.2). Derived from
+        // the function's own template (intrinsic, already-stored data).
+        // NOTE: concise methods/getters/setters are also non-constructors per
+        // spec, but FuncTemplate doesn't yet flag them (follow-up).
+        Some(ObjectSlot(kind: FunctionObject(func_template:, ..), ..)) ->
+          !func_template.is_arrow
+          && !func_template.is_generator
+          && !func_template.is_async
+        // Built-in function: read the [[Construct]] capability stored on the
+        // slot — set True for constructor intrinsics at allocation, and copied
+        // from its target by `bind` (§10.4.1.3 step 6). A native's dispatch tag
+        // alone doesn't encode this, so unlike user functions it is stored.
+        Some(ObjectSlot(kind: NativeFunction(constructible:, ..), ..)) ->
+          constructible
+        _ -> False
+      }
+    _ -> False
   }
 }

--- a/src/arc/vm/value.gleam
+++ b/src/arc/vm/value.gleam
@@ -982,7 +982,11 @@ pub type ExoticKind(ctx) {
   FunctionObject(func_template: FuncTemplate, env: Ref)
   /// Built-in function implemented in Gleam, not bytecode.
   /// Callable like any function but dispatches to native code.
-  NativeFunction(native: NativeFnSlot(ctx))
+  /// `constructible` is the stored [[Construct]] capability (ES2024 §7.2.4):
+  /// True for the constructor intrinsics (Array, Map, …) and for bound
+  /// functions whose target is a constructor; False for ordinary built-ins
+  /// (Math.*, prototype methods, promise reaction jobs, …).
+  NativeFunction(native: NativeFnSlot(ctx), constructible: Bool)
   /// Promise object. The visible JS object has this kind, pointing to
   /// an internal PromiseSlot that holds state/reactions.
   PromiseObject(promise_data: Ref)
@@ -1588,50 +1592,63 @@ fn do_refs_in_slot(slot: HeapSlot(ctx), acc: List(Ref)) -> List(Ref) {
       let acc = push_option_ref(prototype, acc)
       case kind {
         FunctionObject(env: env_ref, func_template: _) -> [env_ref, ..acc]
-        NativeFunction(Dispatch(ErrorNative(ErrorConstructor(proto: ref))))
-        | NativeFunction(Dispatch(ErrorNative(DomExceptionConstructor(
-            proto: ref,
-          ))))
-        | NativeFunction(Dispatch(MapNative(MapConstructor(proto: ref))))
-        | NativeFunction(Dispatch(DateNative(DateConstructor(proto: ref))))
-        | NativeFunction(Dispatch(SetNative(SetConstructor(proto: ref))))
-        | NativeFunction(Dispatch(WeakMapNative(WeakMapConstructor(proto: ref))))
-        | NativeFunction(Dispatch(WeakSetNative(WeakSetConstructor(proto: ref)))) -> [
-          ref,
-          ..acc
-        ]
-        NativeFunction(Call(BoundFunction(target:, bound_this:, bound_args:))) ->
+        NativeFunction(Dispatch(ErrorNative(ErrorConstructor(proto: ref))), ..)
+        | NativeFunction(
+            Dispatch(ErrorNative(DomExceptionConstructor(proto: ref))),
+            ..,
+          )
+        | NativeFunction(Dispatch(MapNative(MapConstructor(proto: ref))), ..)
+        | NativeFunction(Dispatch(DateNative(DateConstructor(proto: ref))), ..)
+        | NativeFunction(Dispatch(SetNative(SetConstructor(proto: ref))), ..)
+        | NativeFunction(
+            Dispatch(WeakMapNative(WeakMapConstructor(proto: ref))),
+            ..,
+          )
+        | NativeFunction(
+            Dispatch(WeakSetNative(WeakSetConstructor(proto: ref))),
+            ..,
+          ) -> [ref, ..acc]
+        NativeFunction(
+          Call(BoundFunction(target:, bound_this:, bound_args:)),
+          ..,
+        ) ->
           list.fold(
             bound_args,
             push_value_ref(bound_this, [target, ..acc]),
             fn(a, v) { push_value_ref(v, a) },
           )
-        NativeFunction(Call(PromiseResolveFunction(
-          promise_ref:,
-          data_ref:,
-          already_resolved_ref:,
-        )))
-        | NativeFunction(Call(PromiseRejectFunction(
+        NativeFunction(
+          Call(PromiseResolveFunction(
             promise_ref:,
             data_ref:,
             already_resolved_ref:,
-          ))) -> [promise_ref, data_ref, already_resolved_ref, ..acc]
-        NativeFunction(Call(PromiseFinallyFulfill(on_finally:)))
-        | NativeFunction(Call(PromiseFinallyReject(on_finally:))) ->
+          )),
+          ..,
+        )
+        | NativeFunction(
+            Call(PromiseRejectFunction(
+              promise_ref:,
+              data_ref:,
+              already_resolved_ref:,
+            )),
+            ..,
+          ) -> [promise_ref, data_ref, already_resolved_ref, ..acc]
+        NativeFunction(Call(PromiseFinallyFulfill(on_finally:)), ..)
+        | NativeFunction(Call(PromiseFinallyReject(on_finally:)), ..) ->
           push_value_ref(on_finally, acc)
-        NativeFunction(Call(PromiseFinallyValueThunk(value:))) ->
+        NativeFunction(Call(PromiseFinallyValueThunk(value:)), ..) ->
           push_value_ref(value, acc)
-        NativeFunction(Call(PromiseFinallyThrower(reason:))) ->
+        NativeFunction(Call(PromiseFinallyThrower(reason:)), ..) ->
           push_value_ref(reason, acc)
-        NativeFunction(Call(AsyncResume(async_data_ref:, ..))) -> [
+        NativeFunction(Call(AsyncResume(async_data_ref:, ..)), ..) -> [
           async_data_ref,
           ..acc
         ]
-        NativeFunction(Call(AsyncGeneratorResume(data_ref:, ..))) -> [
+        NativeFunction(Call(AsyncGeneratorResume(data_ref:, ..)), ..) -> [
           data_ref,
           ..acc
         ]
-        NativeFunction(Call(AsyncFromSyncClose(sync_iter:))) -> [
+        NativeFunction(Call(AsyncFromSyncClose(sync_iter:)), ..) -> [
           sync_iter,
           ..acc
         ]
@@ -1679,7 +1696,7 @@ fn do_refs_in_slot(slot: HeapSlot(ctx), acc: List(Ref)) -> List(Ref) {
         OrdinaryObject
         | ArrayObject(_)
         | ArgumentsObject(_)
-        | NativeFunction(_)
+        | NativeFunction(..)
         | StringObject(_)
         | NumberObject(_)
         | BooleanObject(_)


### PR DESCRIPTION
## What

Built-ins (`Math.abs`, `JSON.parse`, `Array.prototype.*`), arrow/generator/async functions, and — via `Reflect.construct` — bound non-constructors were all usable with `new`.

## Approach

Model `[[Construct]]` the way the spec does (§7.2.4: "an object with a `[[Construct]]` internal method") and **store** it, rather than enumerate which native variants are constructors in a whitelist (the original approach had already drifted into two diverging copies — `call.gleam` vs `reflect.gleam`).

- Add `constructible: Bool` to the `NativeFunction` slot, set at the allocation chokepoint: `True` for constructor intrinsics (`common.init_type` / `init_type_on`), `False` for ordinary built-ins, promise reaction jobs, and await continuations. `bind` copies the bit from its target — a bound function is a constructor iff its target is (§10.4.1.3 step 6).
- One `object.is_constructor/2` (§7.2.4): user functions derive it from their template (arrow/generator/async); natives read the stored bit. The `new` path and `Reflect.construct` now share it and can't disagree.
- Route bound construction back through `do_construct` so derived classes and primitive wrappers (`new (Number.bind())(7)` → a `Number` object) are handled uniformly, and delete the near-duplicate `construct_value`.
- `Symbol` and `Iterator` are abstract constructors — `IsConstructor` is `true` (they carry `[[Construct]]` and may appear in `extends`) but constructing directly throws.
- Implement `IsConstructor(target)` / `IsConstructor(newTarget)` in `Reflect.construct` per ES2024 §28.1.2.

## Notes

Split out of #11, rebased on current `master` (after #12 and #15 landed). Independent of the other split PRs. Code-only; `pass.txt` is regenerated by the test262 workflow on merge.

## Test plan

- `gleam check`, `gleam format --check src test`, `gleam test` (1201/1201) all clean
- Full `TEST262_EXEC=1` run vs `master`: **+332 tests, 0 regressions** (29841 → 30173, 56.04% → 56.67%)
- Spot-checks: `new Number(5)`/`new String('x')`/`new Boolean(true)` → wrapper objects; `new Math.max(1,2)` → TypeError; `new (Number.bind())(7)` → a Number object; `isConstructor(Symbol)`/`isConstructor(Iterator)` → true while `new Symbol()`/`new Iterator()` throw
