### PR TITLE
Format numbers per ES Number::toString (§6.1.6.1.20)

### DIFF
--- a/src/arc/vm/builtins/arc_math_ffi.erl
+++ b/src/arc/vm/builtins/arc_math_ffi.erl
@@ -1,5 +1,5 @@
 -module(arc_math_ffi).
--export([fround/1]).
+-export([fround/1, js_number_to_string/1]).
 
 %% Math.fround: round a 64-bit float to the nearest 32-bit (IEEE 754
 %% single-precision) float, then widen back to 64-bit. This matches the
@@ -12,3 +12,104 @@ fround(X) when is_float(X) ->
     F32;
 fround(X) when is_integer(X) ->
     fround(float(X)).
+
+%% JS Number.prototype.toString(10) per ES2024 §6.1.6.1.20.
+%% Algorithm (informally):
+%%   - 0 → "0" (also +0, -0)
+%%   - integers in (-1e21, 1e21) → integer notation
+%%   - floats with |x| in [1e-6, 1e21) → decimal notation
+%%   - otherwise → exponential notation "Xe+N" / "Xe-N"
+%% The mantissa has no trailing ".0", and positive exponents include "+".
+js_number_to_string(N) when is_float(N) ->
+    %% Normalize -0 to 0 (per spec, -0 stringifies as "0").
+    Norm = N + 0.0,
+    case Norm == 0.0 of
+        true -> <<"0">>;
+        false ->
+            AbsN = abs(Norm),
+            Trunc = trunc(Norm),
+            IsInt = float(Trunc) == Norm,
+            case IsInt andalso AbsN < 1.0e21 of
+                true ->
+                    list_to_binary(integer_to_list(Trunc));
+                false ->
+                    case AbsN >= 1.0e21 orelse AbsN < 1.0e-6 of
+                        true -> format_js_exponential(Norm);
+                        false -> format_js_decimal(Norm)
+                    end
+            end
+    end;
+js_number_to_string(N) when is_integer(N) ->
+    list_to_binary(integer_to_list(N)).
+
+%% Format using Erlang short form, then convert to JS exponential format.
+%% Erlang: "1.0e21" or "1.5e-7"
+%% JS:     "1e+21" or "1.5e-7"
+format_js_exponential(N) ->
+    Short = erlang:float_to_list(N, [short]),
+    case string:split(Short, "e") of
+        [Mantissa, Exp] ->
+            CleanMantissa = strip_trailing_zero_dot(Mantissa),
+            CleanExp = case Exp of
+                [$- | _] -> Exp;
+                [$+ | _] -> Exp;
+                _ -> [$+ | Exp]
+            end,
+            list_to_binary([CleanMantissa, $e, CleanExp]);
+        _ ->
+            list_to_binary(Short)
+    end.
+
+%% Format with decimals notation, trimming trailing zeros.
+%% Use a wide format then strip.
+format_js_decimal(N) ->
+    %% Use erlang's short form, which for in-range numbers gives decimal output.
+    Short = erlang:float_to_list(N, [short]),
+    case string:split(Short, "e") of
+        [Mantissa, Exp] ->
+            %% Erlang gave us exponential but we want decimal — convert.
+            ExpInt = list_to_integer(Exp),
+            decimal_from_exp(Mantissa, ExpInt);
+        _ ->
+            list_to_binary(strip_trailing_zero_dot(Short))
+    end.
+
+%% Convert "1.0" + exponent into decimal string.
+decimal_from_exp(Mantissa, Exp) ->
+    %% Split mantissa around the decimal point
+    {IntPart, FracPart} = case string:split(Mantissa, ".") of
+        [I, F] -> {I, F};
+        [I] -> {I, ""}
+    end,
+    %% Handle negative
+    {Sign, IntPartClean} = case IntPart of
+        [$- | Rest] -> {"-", Rest};
+        _ -> {"", IntPart}
+    end,
+    Combined = IntPartClean ++ FracPart,
+    DotPos = length(IntPartClean) + Exp,
+    Result =
+        if
+            DotPos =< 0 ->
+                "0." ++ lists:duplicate(-DotPos, $0) ++ Combined;
+            DotPos >= length(Combined) ->
+                Combined ++ lists:duplicate(DotPos - length(Combined), $0);
+            true ->
+                {Before, After} = lists:split(DotPos, Combined),
+                Before ++ "." ++ After
+        end,
+    Trimmed = strip_trailing_zero_dot(Result),
+    list_to_binary(Sign ++ Trimmed).
+
+%% Strip trailing ".0" or trailing zeros after decimal.
+%% "1.0" → "1"; "1.500" → "1.5"; "100" → "100"
+strip_trailing_zero_dot(S) ->
+    case string:find(S, ".") of
+        nomatch -> S;
+        _ ->
+            Stripped = string:trim(S, trailing, "0"),
+            case string:trim(Stripped, trailing, ".") of
+                "" -> "0";
+                Result -> Result
+            end
+    end.

--- a/src/arc/vm/value.gleam
+++ b/src/arc/vm/value.gleam
@@ -1779,17 +1779,11 @@ fn do_refs_in_slot(slot: HeapSlot(ctx), acc: List(Ref)) -> List(Ref) {
   }
 }
 
-/// Format a JS number as a string. Integer-valued floats omit the decimal.
-pub fn js_format_number(n: Float) -> String {
-  // §6.1.6.1.20 Number::toString: -0 → "0"
-  // BEAM =:= distinguishes -0.0 from 0.0, so normalize first.
-  let n = n +. 0.0
-  let truncated = float.truncate(n)
-  case int.to_float(truncated) == n {
-    True -> int.to_string(truncated)
-    False -> float.to_string(n)
-  }
-}
+/// Format a JS number as a string per ES2024 §6.1.6.1.20 Number::toString.
+/// Delegates to Erlang FFI for proper JS-compatible output (e.g., 1e21 → "1e+21",
+/// 1e-6 → "0.000001", -0 → "0").
+@external(erlang, "arc_math_ffi", "js_number_to_string")
+pub fn js_format_number(n: Float) -> String
 
 /// JS ToBoolean: https://tc39.es/ecma262/#sec-toboolean
 pub fn is_truthy(val: JsValue) -> Bool {


### PR DESCRIPTION
## What

`js_format_number` produced Erlang-style number strings instead of JS-style ones — e.g. `1e21` stringified as `"1.0e21"` rather than `"1e+21"`, and small magnitudes / `-0` were also off.

## Fix

Delegate `js_format_number` to a new `arc_math_ffi:js_number_to_string/1` implementing ES2024 §6.1.6.1.20:

- integers in `(-1e21, 1e21)` → integer notation
- `|x|` in `[1e-6, 1e21)` → decimal notation
- otherwise → exponential (`"1e+21"`, `"1.5e-7"`)
- `-0` → `"0"`; mantissas carry no trailing `.0`; positive exponents include `+`.

## Notes

Split out of #11. Root of the "numbers & math" stack (#15 → #16 → #17 build on this). Code-only; `pass.txt` is regenerated by the test262 workflow on merge to `master`.

## Test plan

- `gleam check` clean
- `gleam test` — 1201/1201
- `gleam format --check src test` clean
