### PR TITLE
Handle ±0 correctly in division (+ is_neg_zero foundation)

### DIFF
--- a/src/arc/vm/builtins/arc_math_ffi.erl
+++ b/src/arc/vm/builtins/arc_math_ffi.erl
@@ -1,5 +1,5 @@
 -module(arc_math_ffi).
--export([fround/1, js_number_to_string/1]).
+-export([fround/1, is_neg_zero/1, js_number_to_string/1]).
 
 %% Math.fround: round a 64-bit float to the nearest 32-bit (IEEE 754
 %% single-precision) float, then widen back to 64-bit. This matches the
@@ -12,6 +12,15 @@ fround(X) when is_float(X) ->
     F32;
 fround(X) when is_integer(X) ->
     fround(float(X)).
+
+%% Detect IEEE 754 negative zero. BEAM floats preserve the sign bit but
+%% Erlang's == and =:= don't reliably distinguish ±0 in all contexts.
+%% We check the sign bit of the IEEE 754 binary representation directly.
+is_neg_zero(X) when is_float(X) ->
+    <<Sign:1, _:63>> = <<X:64/float>>,
+    X == 0.0 andalso Sign =:= 1;
+is_neg_zero(_) ->
+    false.
 
 %% JS Number.prototype.toString(10) per ES2024 §6.1.6.1.20.
 %% Algorithm (informally):

--- a/src/arc/vm/builtins/math.gleam
+++ b/src/arc/vm/builtins/math.gleam
@@ -610,6 +610,9 @@ fn count_leading_zeros_loop(n: Int, bit: Int, count: Int) -> Int {
 
 // -- FFI --
 
+@external(erlang, "arc_math_ffi", "is_neg_zero")
+pub fn is_neg_zero(x: Float) -> Bool
+
 @external(erlang, "math", "pow")
 fn float_power(base: Float, exp: Float) -> Float
 

--- a/src/arc/vm/ops/operators.gleam
+++ b/src/arc/vm/ops/operators.gleam
@@ -1,3 +1,4 @@
+import arc/vm/builtins/math as builtins_math
 import arc/vm/opcode.{
   type BinOpKind, type UnaryOpKind, Add, BitAnd, BitNot, BitOr, BitXor, Div, Eq,
   Exp, Gt, GtEq, LogicalNot, Lt, LtEq, Mod, Mul, Neg, NotEq, Pos, ShiftLeft,
@@ -154,24 +155,49 @@ fn num_div(a: JsNum, b: JsNum) -> JsNum {
     | NegInfinity, NegInfinity
     -> NaN
     Infinity, Finite(x) ->
-      case x >=. 0.0 {
-        True -> Infinity
-        False -> NegInfinity
-      }
-    NegInfinity, Finite(x) ->
-      case x >=. 0.0 {
+      case is_negative_float(x) {
         True -> NegInfinity
         False -> Infinity
       }
-    Finite(_), Infinity | Finite(_), NegInfinity -> Finite(0.0)
-    Finite(0.0), Finite(0.0) -> NaN
+    NegInfinity, Finite(x) ->
+      case is_negative_float(x) {
+        True -> Infinity
+        False -> NegInfinity
+      }
+    Finite(x), Infinity ->
+      case is_negative_float(x) {
+        True -> Finite(-0.0)
+        False -> Finite(0.0)
+      }
+    Finite(x), NegInfinity ->
+      case is_negative_float(x) {
+        True -> Finite(0.0)
+        False -> Finite(-0.0)
+      }
+    // 0 / 0 = NaN (covers both ±0 / ±0)
+    Finite(0.0), Finite(0.0)
+    | Finite(-0.0), Finite(0.0)
+    | Finite(0.0), Finite(-0.0)
+    | Finite(-0.0), Finite(-0.0)
+    -> NaN
+    // x / ±0 = ±Infinity (sign depends on both operands)
     Finite(x), Finite(0.0) ->
       case x >. 0.0 {
         True -> Infinity
         False -> NegInfinity
       }
+    Finite(x), Finite(-0.0) ->
+      case x >. 0.0 {
+        True -> NegInfinity
+        False -> Infinity
+      }
     Finite(x), Finite(y) -> Finite(x /. y)
   }
+}
+
+/// Check if a float is negative (including -0.0).
+fn is_negative_float(x: Float) -> Bool {
+  x <. 0.0 || builtins_math.is_neg_zero(x)
 }
 
 fn num_mod(a: JsNum, b: JsNum) -> JsNum {


### PR DESCRIPTION
## What

`1 / -0` returned `+Infinity` instead of `-Infinity` (and other ±0 division cases were wrong).

## Why

`num_div`'s `Finite(0.0)` pattern does not match `Finite(-0.0)` on BEAM, so a `-0` denominator fell through to literal float division.

## Fix

- Add explicit ±0 branches to `num_div` for `x / ±0` and `±Infinity / x`, and treat `0/0` (all sign combinations) as `NaN`.
- Add an `is_negative_float` helper that treats `-0` as negative, backed by a new `arc_math_ffi:is_neg_zero/1` that reads the IEEE-754 sign bit directly (BEAM's `=:=` is unreliable for ±0). Exposed via `builtins_math.is_neg_zero` for reuse by later PRs in this stack.

## Notes

Split out of #11. Stacked on #15 (number formatting); introduces the `is_neg_zero` foundation that #16 (Math.pow) and #17 (Math −0 preservation) build on. Code-only; `pass.txt` is regenerated by the test262 workflow on merge to `master`.

## Test plan

- `gleam check` clean
- `gleam test` — 1201/1201
- `gleam format --check src test` clean
