### PR TITLE
Parse exponential number literals (1e10, 1e+20)

### DIFF
--- a/src/arc/parser/arc_parser_ffi.erl
+++ b/src/arc/parser/arc_parser_ffi.erl
@@ -6,12 +6,31 @@ parse_float(S) ->
         {ok, erlang:binary_to_float(S)}
     catch
         error:badarg ->
-            %% Try adding .0 for integer-like strings with exponent
-            try
-                {ok, erlang:binary_to_float(<<S/binary, ".0">>)}
-            catch
-                error:badarg -> {error, nil}
+            %% Erlang's binary_to_float requires a decimal point. For inputs
+            %% like "1e10" or "1E20" we insert ".0" before the exponent so the
+            %% string becomes "1.0e10" / "1.0E20" which Erlang accepts.
+            case insert_dot_before_exp(S) of
+                {ok, S2} ->
+                    try
+                        {ok, erlang:binary_to_float(S2)}
+                    catch
+                        error:badarg -> {error, nil}
+                    end;
+                error -> {error, nil}
             end
+    end.
+
+%% Insert ".0" before the first 'e' or 'E' in a binary, if no '.' precedes it.
+%% Returns {ok, NewBinary} or `error` if no exponent or already has decimal.
+insert_dot_before_exp(S) ->
+    case binary:match(S, [<<"e">>, <<"E">>]) of
+        {Pos, _Len} ->
+            <<Mantissa:Pos/binary, Rest/binary>> = S,
+            case binary:match(Mantissa, <<".">>) of
+                nomatch -> {ok, <<Mantissa/binary, ".0", Rest/binary>>};
+                _ -> error
+            end;
+        nomatch -> error
     end.
 
 %% Decode a JavaScript string literal's escape sequences per ES2024 §12.9.4.


### PR DESCRIPTION
## What

Exponential number literals like `1e10` and `1e+20` parsed as `0.0`.

`erlang:binary_to_float/1` requires a decimal point, so `"1e10"` raised `badarg`; the existing fallback appended `".0"` *after* the exponent (`"1e10.0"` — still invalid), so the value defaulted to `0.0`. Replaced with `insert_dot_before_exp/1`, which inserts `".0"` before the exponent (`"1e10"` → `"1.0e10"`) when the mantissa has no decimal point.

## Notes

Split out of #11. Re-opened against `master`: this was previously #13, but that PR got merged into its stacked base (the string-escape branch) rather than `master`, so the fix never actually landed. Now rebased directly on current `master`. Code-only.

## Test plan

- `gleam check`, `gleam test` (1201/1201), `gleam format --check src test` all clean