### PR TITLE
Number/Math spec compliance: ±0 division, Math.pow, Math built-in −0

### DIFF
--- a/src/arc/vm/builtins/arc_math_ffi.erl
+++ b/src/arc/vm/builtins/arc_math_ffi.erl
@@ -1,5 +1,5 @@
 -module(arc_math_ffi).
--export([fround/1, js_number_to_string/1]).
+-export([fround/1, is_neg_zero/1, js_number_to_string/1]).
 
 %% Math.fround: round a 64-bit float to the nearest 32-bit (IEEE 754
 %% single-precision) float, then widen back to 64-bit. This matches the
@@ -12,6 +12,15 @@ fround(X) when is_float(X) ->
     F32;
 fround(X) when is_integer(X) ->
     fround(float(X)).
+
+%% Detect IEEE 754 negative zero. BEAM floats preserve the sign bit but
+%% Erlang's == and =:= don't reliably distinguish ±0 in all contexts.
+%% We check the sign bit of the IEEE 754 binary representation directly.
+is_neg_zero(X) when is_float(X) ->
+    <<Sign:1, _:63>> = <<X:64/float>>,
+    X == 0.0 andalso Sign =:= 1;
+is_neg_zero(_) ->
+    false.
 
 %% JS Number.prototype.toString(10) per ES2024 §6.1.6.1.20.
 %% Algorithm (informally):

--- a/src/arc/vm/builtins/math.gleam
+++ b/src/arc/vm/builtins/math.gleam
@@ -113,10 +113,10 @@ pub fn dispatch(
     MathImul -> math_imul(args, state)
     MathExpm1 -> math_expm1(args, state)
     MathLog1p -> math_log1p(args, state)
-    MathSinh -> finite_passthrough(args, state, ffi_math_sinh)
+    MathSinh -> neg_zero_preserving(args, state, ffi_math_sinh)
     MathCosh -> math_cosh(args, state)
     MathTanh -> math_tanh(args, state)
-    MathAsinh -> finite_passthrough(args, state, ffi_math_asinh)
+    MathAsinh -> neg_zero_preserving(args, state, ffi_math_asinh)
     MathAcosh -> math_acosh(args, state)
     MathAtanh -> math_atanh(args, state)
   }
@@ -175,7 +175,12 @@ fn math_max(
     list.fold(args, NegInfinity, fn(acc, arg) {
       case acc, to_number(arg) {
         NaN, _ | _, NaN -> NaN
-        Finite(a), Finite(b) if a >=. b -> Finite(a)
+        Finite(a), Finite(b) if a >=. b ->
+          // Per spec: Math.max(+0, -0) → +0
+          case a <=. b && is_neg_zero(a) {
+            True -> Finite(b)
+            False -> Finite(a)
+          }
         Finite(_), Finite(b) -> Finite(b)
         Infinity, _ | _, Infinity -> Infinity
         NegInfinity, other | other, NegInfinity -> other
@@ -193,7 +198,12 @@ fn math_min(
     list.fold(args, Infinity, fn(acc, arg) {
       case acc, to_number(arg) {
         NaN, _ | _, NaN -> NaN
-        Finite(a), Finite(b) if a <=. b -> Finite(a)
+        Finite(a), Finite(b) if a <=. b ->
+          // Per spec: Math.min(+0, -0) → -0
+          case a >=. b && is_neg_zero(b) {
+            True -> Finite(b)
+            False -> Finite(a)
+          }
         Finite(_), Finite(b) -> Finite(b)
         NegInfinity, _ | _, NegInfinity -> NegInfinity
         Infinity, other | other, Infinity -> other
@@ -292,12 +302,16 @@ fn math_cbrt(
   use x <- math_unary(args, state)
   case x {
     Finite(n) ->
-      case n <. 0.0 {
-        True -> {
-          let result = float_power(float.absolute_value(n), 1.0 /. 3.0)
-          Finite(float.negate(result))
-        }
-        False -> Finite(float_power(n, 1.0 /. 3.0))
+      case is_neg_zero(n) {
+        True -> Finite(-0.0)
+        False ->
+          case n <. 0.0 {
+            True -> {
+              let result = float_power(float.absolute_value(n), 1.0 /. 3.0)
+              Finite(float.negate(result))
+            }
+            False -> Finite(float_power(n, 1.0 /. 3.0))
+          }
       }
     NaN -> NaN
     Infinity -> Infinity
@@ -368,7 +382,11 @@ fn math_expm1(
 ) -> #(State, Result(JsValue, JsValue)) {
   use x <- math_unary(args, state)
   case x {
-    Finite(n) -> Finite(ffi_math_exp(n) -. 1.0)
+    Finite(n) ->
+      case is_neg_zero(n) {
+        True -> Finite(-0.0)
+        False -> Finite(ffi_math_exp(n) -. 1.0)
+      }
     NaN -> NaN
     Infinity -> Infinity
     NegInfinity -> Finite(-1.0)
@@ -384,7 +402,11 @@ fn math_log1p(
   case x {
     Finite(n) if n <. -1.0 -> NaN
     Finite(-1.0) -> NegInfinity
-    Finite(n) -> Finite(ffi_math_log(1.0 +. n))
+    Finite(n) ->
+      case is_neg_zero(n) {
+        True -> Finite(-0.0)
+        False -> Finite(ffi_math_log(1.0 +. n))
+      }
     NaN | NegInfinity -> NaN
     Infinity -> Infinity
   }
@@ -410,7 +432,11 @@ fn math_tanh(
 ) -> #(State, Result(JsValue, JsValue)) {
   use x <- math_unary(args, state)
   case x {
-    Finite(n) -> Finite(ffi_math_tanh(n))
+    Finite(n) ->
+      case is_neg_zero(n) {
+        True -> Finite(-0.0)
+        False -> Finite(ffi_math_tanh(n))
+      }
     NaN -> NaN
     Infinity -> Finite(1.0)
     NegInfinity -> Finite(-1.0)
@@ -444,7 +470,11 @@ fn math_atanh(
     Finite(n) if n <. -1.0 || n >. 1.0 -> NaN
     Finite(-1.0) -> NegInfinity
     Finite(1.0) -> Infinity
-    Finite(n) -> Finite(ffi_math_atanh(n))
+    Finite(n) ->
+      case is_neg_zero(n) {
+        True -> Finite(-0.0)
+        False -> Finite(ffi_math_atanh(n))
+      }
     _ -> NaN
   }
 }
@@ -461,6 +491,23 @@ fn math_unary(
 ) -> #(State, Result(JsValue, JsValue)) {
   let x = helpers.get_num_arg(args, 0, to_number)
   #(state, Ok(JsNumber(apply(x))))
+}
+
+/// Like finite_passthrough but preserves -0.0 (for sinh, asinh, etc.)
+fn neg_zero_preserving(
+  args: List(JsValue),
+  state: State,
+  f: fn(Float) -> Float,
+) -> #(State, Result(JsValue, JsValue)) {
+  use x <- math_unary(args, state)
+  case x {
+    Finite(n) ->
+      case is_neg_zero(n) {
+        True -> Finite(-0.0)
+        False -> Finite(f(n))
+      }
+    other -> other
+  }
 }
 
 /// Unary op where Finite(n) -> Finite(f(n)) and non-finite passes through.
@@ -540,39 +587,154 @@ pub fn to_number(val: JsValue) -> value.JsNum {
 }
 
 /// JS Math.round: round half toward +Infinity.
-/// Math.round(-0.5) → 0, Math.round(0.5) → 1
+/// Math.round(-0.5) → -0, Math.round(0.5) → 1
 fn js_round(n: Float) -> Float {
-  let floored = ffi_math_floor(n)
-  case n -. floored >=. 0.5 {
-    True -> floored +. 1.0
-    False -> floored
+  case is_neg_zero(n) {
+    True -> n
+    False -> {
+      let floored = ffi_math_floor(n)
+      case n -. floored >=. 0.5 {
+        True -> floored +. 1.0
+        False -> {
+          // Per spec, if result is 0 and input was negative, return -0
+          case floored == 0.0 && n <. 0.0 {
+            True -> -0.0
+            False -> floored
+          }
+        }
+      }
+    }
   }
 }
 
 fn js_trunc(n: Float) -> Float {
-  int.to_float(value.float_to_int(n))
+  case is_neg_zero(n) {
+    // -0 → -0
+    True -> n
+    False -> {
+      let truncated = int.to_float(value.float_to_int(n))
+      // Values in (-1, 0) truncate to -0 per spec
+      case truncated == 0.0 && n <. 0.0 {
+        True -> -0.0
+        False -> truncated
+      }
+    }
+  }
 }
 
-/// Exponentiation with special-value handling (mirrors vm.gleam's num_exp).
-fn num_exp(a: value.JsNum, b: value.JsNum) -> value.JsNum {
-  case a, b {
-    _, Finite(0.0) -> Finite(1.0)
+/// Exponentiation per ES2024 §6.1.6.1.3 Number::exponentiate.
+pub fn num_exp(base: value.JsNum, exp: value.JsNum) -> value.JsNum {
+  case base, exp {
+    // 1. If exponent is NaN, return NaN
     _, NaN -> NaN
+    // 2. If exponent is +0 or -0, return 1 (even for NaN/Infinity base)
+    _, Finite(0.0) -> Finite(1.0)
+    // 3. If base is NaN, return NaN
     NaN, _ -> NaN
-    Finite(x), Finite(y) -> Finite(float_power(x, y))
+    // 4-5. ±Infinity base with ±Infinity exponent
+    Infinity, Infinity -> Infinity
+    Infinity, NegInfinity -> Finite(0.0)
+    NegInfinity, Infinity -> Infinity
+    NegInfinity, NegInfinity -> Finite(0.0)
+    // abs(base) vs 1 with ±Infinity exponent
+    Finite(x), Infinity -> num_exp_finite_inf(x)
+    Finite(x), NegInfinity -> num_exp_finite_neginf(x)
+    // 6-7. Base is +Infinity
     Infinity, Finite(y) ->
       case y >. 0.0 {
         True -> Infinity
         False -> Finite(0.0)
       }
+    // 8-11. Base is -Infinity
     NegInfinity, Finite(y) ->
       case y >. 0.0 {
-        True -> Infinity
-        False -> Finite(0.0)
+        True ->
+          case is_odd_integer(y) {
+            True -> NegInfinity
+            False -> Infinity
+          }
+        False ->
+          case is_odd_integer(y) {
+            True -> Finite(-0.0)
+            False -> Finite(0.0)
+          }
       }
-    _, Infinity -> NaN
-    _, NegInfinity -> NaN
+    // 12-17. Base is ±0
+    Finite(x), Finite(y) -> num_exp_finite(x, y)
   }
+}
+
+fn num_exp_finite_inf(x: Float) -> value.JsNum {
+  let abs_x = float.absolute_value(x)
+  case abs_x >. 1.0 {
+    True -> Infinity
+    False ->
+      case abs_x <. 1.0 {
+        True -> Finite(0.0)
+        // abs == 1
+        False -> NaN
+      }
+  }
+}
+
+fn num_exp_finite_neginf(x: Float) -> value.JsNum {
+  let abs_x = float.absolute_value(x)
+  case abs_x >. 1.0 {
+    True -> Finite(0.0)
+    False ->
+      case abs_x <. 1.0 {
+        True -> Infinity
+        // abs == 1
+        False -> NaN
+      }
+  }
+}
+
+fn num_exp_finite(x: Float, y: Float) -> value.JsNum {
+  case is_neg_zero(x) {
+    // Base is -0
+    True ->
+      case y >. 0.0 {
+        True ->
+          case is_odd_integer(y) {
+            True -> Finite(-0.0)
+            False -> Finite(0.0)
+          }
+        False ->
+          case is_odd_integer(y) {
+            True -> NegInfinity
+            False -> Infinity
+          }
+      }
+    False ->
+      case x == 0.0 {
+        // Base is +0
+        True ->
+          case y >. 0.0 {
+            True -> Finite(0.0)
+            False -> Infinity
+          }
+        // Normal finite case
+        False ->
+          case x <. 0.0 {
+            True -> {
+              let truncated = int.to_float(value.float_to_int(y))
+              case truncated == y {
+                True -> Finite(float_power(x, y))
+                // Non-integer exponent with negative base
+                False -> NaN
+              }
+            }
+            False -> Finite(float_power(x, y))
+          }
+      }
+  }
+}
+
+/// Check if a float is an odd integer.
+fn is_odd_integer(f: Float) -> Bool {
+  let truncated = value.float_to_int(f)
+  int.to_float(truncated) == f && int.is_odd(truncated)
 }
 
 /// ToUint32: convert a float to a 32-bit unsigned integer (ES S7.1.7).

--- a/src/arc/vm/builtins/math.gleam
+++ b/src/arc/vm/builtins/math.gleam
@@ -610,6 +610,9 @@ fn count_leading_zeros_loop(n: Int, bit: Int, count: Int) -> Int {
 
 // -- FFI --
 
+@external(erlang, "arc_math_ffi", "is_neg_zero")
+pub fn is_neg_zero(x: Float) -> Bool
+
 @external(erlang, "math", "pow")
 fn float_power(base: Float, exp: Float) -> Float
 

--- a/src/arc/vm/ops/operators.gleam
+++ b/src/arc/vm/ops/operators.gleam
@@ -1,3 +1,4 @@
+import arc/vm/builtins/math as builtins_math
 import arc/vm/opcode.{
   type BinOpKind, type UnaryOpKind, Add, BitAnd, BitNot, BitOr, BitXor, Div, Eq,
   Exp, Gt, GtEq, LogicalNot, Lt, LtEq, Mod, Mul, Neg, NotEq, Pos, ShiftLeft,
@@ -154,24 +155,49 @@ fn num_div(a: JsNum, b: JsNum) -> JsNum {
     | NegInfinity, NegInfinity
     -> NaN
     Infinity, Finite(x) ->
-      case x >=. 0.0 {
-        True -> Infinity
-        False -> NegInfinity
-      }
-    NegInfinity, Finite(x) ->
-      case x >=. 0.0 {
+      case is_negative_float(x) {
         True -> NegInfinity
         False -> Infinity
       }
-    Finite(_), Infinity | Finite(_), NegInfinity -> Finite(0.0)
-    Finite(0.0), Finite(0.0) -> NaN
+    NegInfinity, Finite(x) ->
+      case is_negative_float(x) {
+        True -> Infinity
+        False -> NegInfinity
+      }
+    Finite(x), Infinity ->
+      case is_negative_float(x) {
+        True -> Finite(-0.0)
+        False -> Finite(0.0)
+      }
+    Finite(x), NegInfinity ->
+      case is_negative_float(x) {
+        True -> Finite(0.0)
+        False -> Finite(-0.0)
+      }
+    // 0 / 0 = NaN (covers both ±0 / ±0)
+    Finite(0.0), Finite(0.0)
+    | Finite(-0.0), Finite(0.0)
+    | Finite(0.0), Finite(-0.0)
+    | Finite(-0.0), Finite(-0.0)
+    -> NaN
+    // x / ±0 = ±Infinity (sign depends on both operands)
     Finite(x), Finite(0.0) ->
       case x >. 0.0 {
         True -> Infinity
         False -> NegInfinity
       }
+    Finite(x), Finite(-0.0) ->
+      case x >. 0.0 {
+        True -> NegInfinity
+        False -> Infinity
+      }
     Finite(x), Finite(y) -> Finite(x /. y)
   }
+}
+
+/// Check if a float is negative (including -0.0).
+fn is_negative_float(x: Float) -> Bool {
+  x <. 0.0 || builtins_math.is_neg_zero(x)
 }
 
 fn num_mod(a: JsNum, b: JsNum) -> JsNum {

--- a/src/arc/vm/ops/operators.gleam
+++ b/src/arc/vm/ops/operators.gleam
@@ -213,24 +213,7 @@ fn num_mod(a: JsNum, b: JsNum) -> JsNum {
 }
 
 fn num_exp(a: JsNum, b: JsNum) -> JsNum {
-  case a, b {
-    _, Finite(0.0) -> Finite(1.0)
-    _, NaN -> NaN
-    NaN, _ -> NaN
-    Finite(x), Finite(y) -> Finite(float_power(x, y))
-    Infinity, Finite(y) ->
-      case y >. 0.0 {
-        True -> Infinity
-        False -> Finite(0.0)
-      }
-    NegInfinity, Finite(y) ->
-      case y >. 0.0 {
-        True -> Infinity
-        False -> Finite(0.0)
-      }
-    _, Infinity -> NaN
-    _, NegInfinity -> NaN
-  }
+  builtins_math.num_exp(a, b)
 }
 
 pub fn num_negate(n: JsNum) -> JsNum {


### PR DESCRIPTION
## What

Three related number/Math spec fixes, split out of #11 and rebased on current `master` (after #15 landed). Two logical commits:

**1. `1 / -0` returned `+Infinity`** — `num_div`'s `Finite(0.0)` pattern doesn't match `Finite(-0.0)` on BEAM, so a `-0` denominator fell through to literal float division. Added explicit ±0 branches for `x / ±0` and `±Infinity / x`, plus a new `arc_math_ffi:is_neg_zero/1` (IEEE-754 sign bit; BEAM's `=:=` is unreliable for ±0), exposed via `builtins_math.is_neg_zero`.

**2. `Math.pow` + Math built-in −0** — rewrote `num_exp` per ES2024 §6.1.6.1.3 (full ±Infinity / odd-integer / ±0 / negative-base matrix), made it `pub`, and removed the duplicate in `ops/operators`. `Math.trunc/round/cbrt/expm1/log1p/atanh/tanh/sinh/asinh` now short-circuit on `-0` before the FFI normalizes the sign away, and `Math.min`/`Math.max` preserve the spec −0/+0 ordering.

## Why one PR (not three stacked)

These share the `is_neg_zero` foundation, so they can't be cleanly independent. They were originally planned as a stack on the number-formatting PR (#15), but #15 has already merged to `master` and stacked-merging the rest into their parent branches missed `master` (see #13/#16). Bundling into one PR → `master` is merge-safe; the two commits keep the fixes reviewable separately.

## Test plan

- `gleam check`, `gleam test` (1201/1201), `gleam format --check src test` all clean
- Full `TEST262_EXEC=1` run vs `master`: **+61 tests, 0 regressions** (29841 → 29902)