### PR TITLE
Make methods, getters, and setters non-constructible

### DIFF
--- a/src/arc/compiler.gleam
+++ b/src/arc/compiler.gleam
@@ -89,6 +89,8 @@ fn compile_module_with_scope(
           False,
           False,
           False,
+          // Script / module body — not a constructor.
+          False,
           None,
           resolved.this_slot,
         )
@@ -213,6 +215,8 @@ pub fn compile_eval_direct(
             False,
             False,
             False,
+            False,
+            // Eval body — not a constructor.
             False,
             None,
             resolved.this_slot,
@@ -388,6 +392,8 @@ fn compile_script(
           False,
           False,
           False,
+          // Script / module body — not a constructor.
+          False,
           None,
           resolved.this_slot,
         )
@@ -522,6 +528,7 @@ fn compile_child(
     child.is_derived_constructor,
     child.is_generator,
     child.is_async,
+    child.is_constructor,
     local_names,
     resolved.this_slot,
   )

--- a/src/arc/compiler/emit.gleam
+++ b/src/arc/compiler/emit.gleam
@@ -93,6 +93,10 @@ pub type CompiledChild {
     is_derived_constructor: Bool,
     is_generator: Bool,
     is_async: Bool,
+    /// Stored [[Construct]] capability: True for normal functions and class
+    /// constructors; False for arrows, generators, async, and methods /
+    /// getters / setters. (cf. QuickJS `is_constructor` / JSC `ConstructAbility`.)
+    is_constructor: Bool,
     /// True if this function contains a syntactic `eval(...)` call with
     /// identifier callee. Such functions get all locals boxed and a
     /// name→index table stored on FuncTemplate so direct eval can see them.
@@ -1012,6 +1016,8 @@ fn collect_hoisted_funcs(
               False,
               is_gen,
               is_async,
+              // Function declaration: a constructor unless gen/async.
+              !is_gen && !is_async,
             )
           let #(e, idx) = add_child_function(e, child)
           #(e, [#(name, idx), ..funcs])
@@ -1272,6 +1278,7 @@ fn compile_function_body(
   is_arrow: Bool,
   is_generator: Bool,
   is_async: Bool,
+  is_constructor: Bool,
 ) -> CompiledChild {
   let stmts = case body {
     ast.BlockStatement(s) -> s
@@ -1414,6 +1421,7 @@ fn compile_function_body(
     is_derived_constructor: False,
     is_generator:,
     is_async:,
+    is_constructor:,
     has_eval_call: e.has_eval_call,
     references_this: e.references_this,
   )
@@ -2383,7 +2391,17 @@ fn emit_expr(e: Emitter, expr: ast.Expression) -> Result(Emitter, EmitError) {
     // Function expression
     ast.FunctionExpression(name, params, body, is_gen, is_async) -> {
       let child =
-        compile_function_body(e, name, params, body, False, is_gen, is_async)
+        compile_function_body(
+          e,
+          name,
+          params,
+          body,
+          False,
+          is_gen,
+          is_async,
+          // Normal function expression: a constructor unless gen/async.
+          !is_gen && !is_async,
+        )
       let #(e, idx) = add_child_function(e, child)
       Ok(emit_ir(e, IrMakeClosure(idx)))
     }
@@ -2396,7 +2414,16 @@ fn emit_expr(e: Emitter, expr: ast.Expression) -> Result(Emitter, EmitError) {
         ast.ArrowBodyBlock(stmt) -> stmt
       }
       let child =
-        compile_function_body(e, None, params, body_stmt, True, False, is_async)
+        compile_function_body(
+          e,
+          None,
+          params,
+          body_stmt,
+          True,
+          False,
+          is_async,
+          False,
+        )
       let #(e, idx) = add_child_function(e, child)
       Ok(emit_ir(e, IrMakeClosure(idx)))
     }
@@ -2678,6 +2705,8 @@ fn emit_named_expr(
           False,
           is_gen,
           is_async,
+          // Named function expression: a constructor unless gen/async.
+          !is_gen && !is_async,
         )
       let #(e, idx) = add_child_function(e, child)
       Ok(emit_ir(e, IrMakeClosure(idx)))
@@ -2698,6 +2727,8 @@ fn emit_named_expr(
           True,
           False,
           is_async,
+          // Arrow function — not a constructor.
+          False,
         )
       let #(e, idx) = add_child_function(e, child)
       Ok(emit_ir(e, IrMakeClosure(idx)))
@@ -2712,6 +2743,36 @@ fn emit_named_expr(
 
 /// Emit one property in an object literal. Object is already on the stack.
 /// All handlers leave the object on the stack for the next property.
+/// Compile an object-literal *method* value — a concise method, getter, or
+/// setter — so it is NOT a constructor (methods/accessors have no
+/// [[Construct]], so `new o.m()` must throw). These values are always
+/// FunctionExpressions; fall back defensively for anything unexpected.
+fn emit_method_value(
+  e: Emitter,
+  value: ast.Expression,
+  name: Option(String),
+) -> Result(Emitter, EmitError) {
+  case value {
+    ast.FunctionExpression(_, params, body, is_gen, is_async) -> {
+      let child =
+        compile_function_body(
+          e,
+          name,
+          params,
+          body,
+          False,
+          is_gen,
+          is_async,
+          // method / getter / setter — not a constructor
+          False,
+        )
+      let #(e, idx) = add_child_function(e, child)
+      Ok(emit_ir(e, IrMakeClosure(idx)))
+    }
+    _ -> emit_expr(e, value)
+  }
+}
+
 fn emit_object_property(
   e: Emitter,
   prop: ast.Property,
@@ -2724,6 +2785,7 @@ fn emit_object_property(
       value:,
       kind: ast.Init,
       computed: False,
+      method:,
       ..,
     )
     | ast.Property(
@@ -2731,9 +2793,14 @@ fn emit_object_property(
         value:,
         kind: ast.Init,
         computed: False,
+        method:,
         ..,
       ) -> {
-      use e <- result.map(emit_named_expr(e, value, name))
+      // `{ m() {} }` is a method (not a constructor); `{ x: v }` is data.
+      use e <- result.map(case method {
+        True -> emit_method_value(e, value, Some(name))
+        False -> emit_named_expr(e, value, name)
+      })
       emit_ir(e, IrDefineField(name))
     }
 
@@ -2745,19 +2812,26 @@ fn emit_object_property(
       value:,
       kind: ast.Init,
       computed: False,
+      method:,
       ..,
     ) -> {
       let e = push_const(e, JsNumber(Finite(n)))
-      use e <- result.map(emit_expr(e, value))
+      use e <- result.map(case method {
+        True -> emit_method_value(e, value, None)
+        False -> emit_expr(e, value)
+      })
       emit_ir(e, IrDefineFieldComputed)
     }
 
     // Computed key: {[expr]: value}
     // Emit key, emit value, IrDefineFieldComputed — pops both, keeps obj.
     // The VM handles ToPropertyKey (Symbol preserved, else ToString).
-    ast.Property(key:, value:, kind: ast.Init, computed: True, ..) -> {
+    ast.Property(key:, value:, kind: ast.Init, computed: True, method:, ..) -> {
       use e <- result.try(emit_expr(e, key))
-      use e <- result.map(emit_expr(e, value))
+      use e <- result.map(case method {
+        True -> emit_method_value(e, value, None)
+        False -> emit_expr(e, value)
+      })
       emit_ir(e, IrDefineFieldComputed)
     }
 
@@ -2785,7 +2859,7 @@ fn emit_object_property(
         computed: False,
         ..,
       ) -> {
-      use e <- result.map(emit_named_expr(e, value, "get " <> name))
+      use e <- result.map(emit_method_value(e, value, Some("get " <> name)))
       emit_ir(e, IrDefineAccessor(name, opcode.Getter))
     }
 
@@ -2804,7 +2878,7 @@ fn emit_object_property(
         computed: False,
         ..,
       ) -> {
-      use e <- result.map(emit_named_expr(e, value, "set " <> name))
+      use e <- result.map(emit_method_value(e, value, Some("set " <> name)))
       emit_ir(e, IrDefineAccessor(name, opcode.Setter))
     }
 
@@ -2812,12 +2886,12 @@ fn emit_object_property(
     // Stack: emit key, emit fn → DefineAccessorComputed
     ast.Property(key:, value:, kind: ast.Get, ..) -> {
       use e <- result.try(emit_expr(e, key))
-      use e <- result.map(emit_expr(e, value))
+      use e <- result.map(emit_method_value(e, value, None))
       emit_ir(e, IrDefineAccessorComputed(opcode.Getter))
     }
     ast.Property(key:, value:, kind: ast.Set, ..) -> {
       use e <- result.try(emit_expr(e, key))
-      use e <- result.map(emit_expr(e, value))
+      use e <- result.map(emit_method_value(e, value, None))
       emit_ir(e, IrDefineAccessorComputed(opcode.Setter))
     }
 
@@ -4136,6 +4210,8 @@ fn compile_derived_class(
       False,
       False,
       False,
+      // Class constructor — IS a constructor.
+      True,
     )
   // Mark as derived constructor
   let child = CompiledChild(..child, is_derived_constructor: True)
@@ -4220,6 +4296,8 @@ fn emit_class_methods(
           False,
           is_gen,
           is_async,
+          // Class method / getter / setter — not a constructor.
+          False,
         )
       let #(e, idx) = add_child_function(e, child)
       let e = emit_ir(e, IrMakeClosure(idx))
@@ -4271,7 +4349,17 @@ fn emit_computed_class_method(
   }
   use e <- result.try(emit_expr(e, key))
   let child =
-    compile_function_body(e, None, params, body, False, is_gen, is_async)
+    compile_function_body(
+      e,
+      None,
+      params,
+      body,
+      False,
+      is_gen,
+      is_async,
+      // Computed class method / getter / setter — not a constructor.
+      False,
+    )
   let #(e, idx) = add_child_function(e, child)
   let e = emit_ir(e, IrMakeClosure(idx))
   let e = case kind {
@@ -4391,6 +4479,8 @@ fn compile_base_class(
       False,
       False,
       False,
+      // Class constructor — IS a constructor.
+      True,
     )
   let #(e, ctor_idx) = add_child_function(e, child)
 

--- a/src/arc/compiler/resolve.gleam
+++ b/src/arc/compiler/resolve.gleam
@@ -51,6 +51,7 @@ pub fn resolve(
   is_derived_constructor: Bool,
   is_generator: Bool,
   is_async: Bool,
+  is_constructor: Bool,
   local_names: Option(List(#(String, Int))),
   this_slot: Option(Int),
 ) -> FuncTemplate {
@@ -69,6 +70,7 @@ pub fn resolve(
     is_derived_constructor:,
     is_generator:,
     is_async:,
+    is_constructor:,
     local_names:,
     this_slot:,
   )

--- a/src/arc/vm/exec/call.gleam
+++ b/src/arc/vm/exec/call.gleam
@@ -1333,10 +1333,12 @@ pub fn do_construct(
   dispatch_fn: DispatchNativeFn,
 ) -> Result(State, #(StepResult, JsValue, State)) {
   case heap.read(state.heap, ctor_ref) {
+    // Functions lacking [[Construct]] — arrows, generators, async functions,
+    // and methods/getters/setters — throw when used with `new` (§7.2.4). The
+    // capability is stored on the template (set at compile from the syntactic
+    // kind); class constructors and normal functions carry it.
     Some(ObjectSlot(kind: FunctionObject(func_template:, ..), ..))
-      if func_template.is_arrow
-      || func_template.is_generator
-      || func_template.is_async
+      if !func_template.is_constructor
     ->
       state.throw_type_error(
         state,

--- a/src/arc/vm/exec/interpreter.gleam
+++ b/src/arc/vm/exec/interpreter.gleam
@@ -112,6 +112,7 @@ fn construct_fn_callback(
           is_derived_constructor: False,
           is_generator: False,
           is_async: False,
+          is_constructor: False,
           local_names: None,
           this_slot: None,
         )

--- a/src/arc/vm/ops/object.gleam
+++ b/src/arc/vm/ops/object.gleam
@@ -1652,14 +1652,12 @@ pub fn is_constructor(heap: Heap, value: JsValue) -> Bool {
     JsObject(ref) ->
       case heap.read(heap, ref) {
         // ECMAScript function: a constructor unless it's an arrow, generator,
-        // or async function — those lack [[Construct]] (§10.2). Derived from
-        // the function's own template (intrinsic, already-stored data).
-        // NOTE: concise methods/getters/setters are also non-constructors per
-        // spec, but FuncTemplate doesn't yet flag them (follow-up).
+        // ECMAScript function: read the [[Construct]] capability stored on its
+        // template, set at compile time from the function's syntactic kind
+        // (normal functions + class constructors carry it; arrows, generators,
+        // async functions, and methods/getters/setters do not).
         Some(ObjectSlot(kind: FunctionObject(func_template:, ..), ..)) ->
-          !func_template.is_arrow
-          && !func_template.is_generator
-          && !func_template.is_async
+          func_template.is_constructor
         // Built-in function: read the [[Construct]] capability stored on the
         // slot — set True for constructor intrinsics at allocation, and copied
         // from its target by `bind` (§10.4.1.3 step 6). A native's dispatch tag

--- a/src/arc/vm/value.gleam
+++ b/src/arc/vm/value.gleam
@@ -103,6 +103,13 @@ pub type FuncTemplate {
     is_derived_constructor: Bool,
     is_generator: Bool,
     is_async: Bool,
+    /// Stored [[Construct]] capability (ES2024 §7.2.4), the user-function
+    /// analogue of NativeFunction's `constructible`. True for normal function
+    /// declarations/expressions and class constructors; False for arrows,
+    /// generators, async functions, and methods/getters/setters. Computed at
+    /// compile time from the function's syntactic kind (cf. QuickJS
+    /// `is_constructor` / JSC `ConstructAbility`).
+    is_constructor: Bool,
     /// Present only for functions that contain a direct eval call.
     /// Maps variable name → local slot index. All such locals are boxed
     /// (BoxSlot refs), so direct eval can read/write them by index.

--- a/test/heap_test.gleam
+++ b/test/heap_test.gleam
@@ -24,6 +24,7 @@ fn dummy_template() -> FuncTemplate {
     is_derived_constructor: False,
     is_generator: False,
     is_async: False,
+    is_constructor: False,
     local_names: None,
     this_slot: None,
   )

--- a/test/vm_test.gleam
+++ b/test/vm_test.gleam
@@ -61,6 +61,7 @@ fn make_func(
     is_derived_constructor: False,
     is_generator: False,
     is_async: False,
+    is_constructor: True,
     local_names: None,
     this_slot: None,
   )


### PR DESCRIPTION
## What

`new obj.method()`, `new (getter)()`, and `new class.method()` did not throw — but per spec concise methods, getters, setters, and class methods are created **without** a `[[Construct]]` internal method (§10.2), so they must throw `TypeError`. The bug: once compiled, a method was indistinguishable from a normal function (a method isn't an arrow/generator/async, so the existing flags didn't catch it). The parser knew the kind (`MethodKind`, `Property.method`) but `emit` dropped it.

## Fix

Store the `[[Construct]]` capability on `FuncTemplate` as a positive `is_constructor` bit — the user-function analogue of `NativeFunction`'s `constructible` from #14, and the model both QuickJS (`is_constructor`) and JSC (`ConstructAbility`) use. Computed at emit time from the function's syntactic kind:

- **True**: normal function declarations/expressions, class constructors
- **False**: arrows, generators, async functions, and methods/getters/setters (object-literal *and* class)

`do_construct` now gates on `!is_constructor` (instead of re-deriving arrow/generator/async), and `object.is_constructor` reads the bit directly — so the `new` path and `Reflect.construct` share one stored capability for both native and user functions.

## Test plan

- `gleam check` / `gleam format --check src test` clean; `gleam test` 1201/1201
- Manual: `new o.m()` / `new (getter)()` / `new c.foo()` / `new C.s()` / computed methods → `TypeError`; `new fn()` / `new Class()` / `new (function(){})` / `{f: function(){}}` → construct; `new function*(){}` → `TypeError`
- Full `TEST262_EXEC=1` vs master: **+2, 0 regressions** (30284 → 30286)