### PR TITLE
readable names in emitted erlang

### DIFF
--- a/.github/workflows/aot.yml
+++ b/.github/workflows/aot.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '29'
-          gleam-version: '1.17'
+          gleam-version: '1.18'
           rebar3-version: '3'
       - run: gleam deps download
       - run: gleam build

--- a/.github/workflows/build-avm.yml
+++ b/.github/workflows/build-avm.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '29'
-          gleam-version: '1.17'
+          gleam-version: '1.18'
           rebar3-version: '3'
 
       - run: gleam deps download

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '29'
-          gleam-version: '1.17'
+          gleam-version: '1.18'
           rebar3-version: '3'
           # elixir-version: "1"
       - run: gleam deps download

--- a/.github/workflows/test262-aot.yml
+++ b/.github/workflows/test262-aot.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '29'
-          gleam-version: '1.17'
+          gleam-version: '1.18'
           rebar3-version: '3'
 
       - name: Build

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: '29'
-          gleam-version: '1.17'
+          gleam-version: '1.18'
           rebar3-version: '3'
 
       - name: Build

--- a/aot/gleam.toml
+++ b/aot/gleam.toml
@@ -4,7 +4,7 @@ target = "erlang"
 
 [dependencies]
 arc = { path = ".." }
-carder = { git = "https://github.com/scarletindustries/carder", ref = "978a4b55ae9f0fe9f47ddb6d0d62e76dce0cf691" }
+carder = { git = "https://github.com/scarletindustries/carder", ref = "7ac066a6c4544724bfe09a5a038c411b968a98cb" }
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleam_erlang = ">= 1.0.0 and < 2.0.0"
 argv = ">= 1.0.0 and < 2.0.0"

--- a/aot/gleam.toml
+++ b/aot/gleam.toml
@@ -4,7 +4,7 @@ target = "erlang"
 
 [dependencies]
 arc = { path = ".." }
-carder = { git = "https://github.com/scarletindustries/carder", ref = "ca536730bb66a83ad00fbffdbae06f4d5daad13d" }
+carder = { git = "https://github.com/scarletindustries/carder", ref = "978a4b55ae9f0fe9f47ddb6d0d62e76dce0cf691" }
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleam_erlang = ">= 1.0.0 and < 2.0.0"
 argv = ">= 1.0.0 and < 2.0.0"

--- a/aot/manifest.toml
+++ b/aot/manifest.toml
@@ -9,7 +9,7 @@
 packages = [
   { name = "arc", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "simplifile"], source = "local", path = ".." },
   { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
-  { name = "carder", version = "1.0.0", build_tools = ["gleam"], requirements = ["argv", "gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "https://github.com/scarletindustries/carder", commit = "ca536730bb66a83ad00fbffdbae06f4d5daad13d" },
+  { name = "carder", version = "1.0.0", build_tools = ["gleam"], requirements = ["argv", "gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "https://github.com/scarletindustries/carder", commit = "978a4b55ae9f0fe9f47ddb6d0d62e76dce0cf691" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
@@ -20,7 +20,7 @@ packages = [
 [requirements]
 arc = { path = ".." }
 argv = { version = ">= 1.0.0 and < 2.0.0" }
-carder = { git = "https://github.com/scarletindustries/carder", ref = "ca536730bb66a83ad00fbffdbae06f4d5daad13d" }
+carder = { git = "https://github.com/scarletindustries/carder", ref = "978a4b55ae9f0fe9f47ddb6d0d62e76dce0cf691" }
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }

--- a/aot/manifest.toml
+++ b/aot/manifest.toml
@@ -9,7 +9,7 @@
 packages = [
   { name = "arc", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "simplifile"], source = "local", path = ".." },
   { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
-  { name = "carder", version = "1.0.0", build_tools = ["gleam"], requirements = ["argv", "gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "https://github.com/scarletindustries/carder", commit = "978a4b55ae9f0fe9f47ddb6d0d62e76dce0cf691" },
+  { name = "carder", version = "1.0.0", build_tools = ["gleam"], requirements = ["argv", "gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "https://github.com/scarletindustries/carder", commit = "7ac066a6c4544724bfe09a5a038c411b968a98cb" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
@@ -20,7 +20,7 @@ packages = [
 [requirements]
 arc = { path = ".." }
 argv = { version = ">= 1.0.0 and < 2.0.0" }
-carder = { git = "https://github.com/scarletindustries/carder", ref = "978a4b55ae9f0fe9f47ddb6d0d62e76dce0cf691" }
+carder = { git = "https://github.com/scarletindustries/carder", ref = "7ac066a6c4544724bfe09a5a038c411b968a98cb" }
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }

--- a/aot/src/arc_aot/emit.gleam
+++ b/aot/src/arc_aot/emit.gleam
@@ -103,7 +103,7 @@ fn root_binding_prologue(
   list.fold(bindings, #(wrap, e), fn(acc, entry) {
     let #(wrap, e) = acc
     let #(name, b) = entry
-    let sv = state.slot_var_name(b.slot)
+    let sv = state.slot_var_name(e, b.slot)
     let e = state.set_slot_var(e, b.slot, sv)
     let e = case b.kind {
       scope.VarBinding ->
@@ -182,7 +182,7 @@ fn root_lexical_prologue(
       list.fold(lexical.all_lexical_refs, #(id, e), fn(acc, ref) {
         let #(wrap, e) = acc
         let slot = base + lexical.lexical_ref_offset(ref)
-        let sv = state.slot_var_name(slot)
+        let sv = state.slot_var_name(e, slot)
         let e = state.set_slot_var(e, slot, sv)
         let init = case ref {
           lexical.RefThis -> ir.CallHost("js", "global_this", [])
@@ -261,7 +261,7 @@ pub fn emit_hoists(
         scope.Plain(scope.Local(slot:, boxed: False, ..)) -> {
           // Unboxed root fn slot (no nested fn captures it): fresh Let-
           // rebind + set_slot_var so later top-level reads see the closure.
-          let #(t, e) = state.fresh_var(e)
+          let #(t, e) = state.fresh_slot_var(e, slot)
           let e = state.set_slot_var(e, slot, t)
           let w = fn(tail) {
             wrap(ir.Let(

--- a/aot/src/arc_aot/emit/anf.gleam
+++ b/aot/src/arc_aot/emit/anf.gleam
@@ -189,7 +189,7 @@ fn rebind_slots(e: Emitter2, slots: List(Int)) -> #(Emitter2, List(String)) {
   let #(e, rev) =
     list.fold(slots, #(e, []), fn(acc, slot) {
       let #(e, ns) = acc
-      let #(n, e) = state.fresh_var(e)
+      let #(n, e) = state.fresh_slot_var(e, slot)
       #(state.set_slot_var(e, slot, n), [n, ..ns])
     })
   #(e, list.reverse(rev))

--- a/aot/src/arc_aot/emit/async.gleam
+++ b/aot/src/arc_aot/emit/async.gleam
@@ -3441,7 +3441,7 @@ fn restore_and_seed_go(
   case slots {
     [] -> k(e)
     [#(slot, idx), ..rest] -> {
-      let #(name, e) = state.fresh_var(e)
+      let #(name, e) = state.fresh_slot_var(e, slot)
       let e = state.set_slot_var(e, slot, name)
       use body <- state.map_tree(restore_and_seed_go(e, ctx, rest, k))
       ir.Let([name], ir.TermOp(ir.TupleGet(idx), [ctx.loc_v]), body)
@@ -4583,9 +4583,9 @@ pub fn emit_coroutine_fn(
   let ncap = list.length(captures)
   let stmts = func.body_stmts(body)
   let is_strict = e.strict || ast_util.has_use_strict_directive(stmts)
-  let #(sm_base, e) = state.fresh_fn_name(e)
+  let #(sm_base, e) = state.fresh_fn_name(e, js_name)
   let sm_name = sm_base <> "__sm"
-  let #(outer_name, e) = state.fresh_fn_name(e)
+  let #(outer_name, e) = state.fresh_fn_name(e, js_name)
   let enter = fn(e) {
     state.enter_function(
       e,

--- a/aot/src/arc_aot/emit/class.gleam
+++ b/aot/src/arc_aot/emit/class.gleam
@@ -113,7 +113,7 @@ fn store_class_const(
     True ->
       host_unit_(e, "cell_set", [ir.Var(state.get_slot_var(e, b.slot)), v], k)
     False -> {
-      let vn = state.slot_var_name(b.slot)
+      let vn = state.slot_var_name(e, b.slot)
       use body <- state.map_tree(k(state.set_slot_var(e, b.slot, vn)))
       ir.Let([vn], ir.Values([v]), body)
     }
@@ -766,7 +766,7 @@ fn build_class_init_closure(
   let child_info = scope.function_info(e.tree, child_id)
   // Capture values are read from the PARENT frame BEFORE enter_function.
   let capture_vals = func.build_capture_values(e, child_info)
-  let #(fn_name, e) = state.fresh_fn_name(e)
+  let #(fn_name, e) = state.fresh_fn_name(e, None)
   let #(e_child, save) =
     state.enter_function(
       e,

--- a/aot/src/arc_aot/emit/destructure.gleam
+++ b/aot/src/arc_aot/emit/destructure.gleam
@@ -95,7 +95,7 @@ fn bind_identifier(name: String, v: ir.Value, mode: BindMode) -> Build(Nil) {
             True ->
               anf.host_unit("cell_set", [ir.Var(state.get_slot_var(e, slot)), v])
             False -> fn(e, k) {
-              let #(n, e) = state.fresh_var(e)
+              let #(n, e) = state.fresh_slot_var(e, slot)
               anf.wrap(k(state.set_slot_var(e, slot, n), Nil), ir.Let(
                 [n],
                 ir.Values([v]),

--- a/aot/src/arc_aot/emit/exn.gleam
+++ b/aot/src/arc_aot/emit/exn.gleam
@@ -421,7 +421,7 @@ pub fn catch_binding_prologue(
     |> list.sort(fn(a, b) { int.compare({ a.1 }.slot, { b.1 }.slot) })
   use e, entry, next <- each_(e, bindings, then: k)
   let #(_, b): #(String, Binding) = entry
-  let name = state.slot_var_name(b.slot)
+  let name = state.slot_var_name(e, b.slot)
   let seed = fn(e: Emitter2, init) {
     case b.is_boxed {
       False -> {

--- a/aot/src/arc_aot/emit/expr.gleam
+++ b/aot/src/arc_aot/emit/expr.gleam
@@ -2311,7 +2311,7 @@ fn write_slot(slot: Int, boxed: Bool, v: ir.Value) -> Build(ir.Value) {
           fn(_) { anf.pure(v) },
         )(e, k)
       False -> {
-        let #(name, e) = state.fresh_var(e)
+        let #(name, e) = state.fresh_slot_var(e, slot)
         // Propagate known-number through the unboxed alias so a slot re-read
         // (via read_slot → ir.Var(name)) still elides `is_number` guards.
         let e = case anf.is_known_number(e, v) {

--- a/aot/src/arc_aot/emit/func.gleam
+++ b/aot/src/arc_aot/emit/func.gleam
@@ -294,7 +294,7 @@ fn store_slot(
     True ->
       host_unit_(e, "cell_set", [ir.Var(state.get_slot_var(e, b.slot)), val], k)
     False -> {
-      let name = state.slot_var_name(b.slot)
+      let name = state.slot_var_name(e, b.slot)
       use body <- state.map_tree(k(state.set_slot_var(e, b.slot, name)))
       ir.Let([name], ir.Values([val]), body)
     }
@@ -318,13 +318,13 @@ pub fn unpack_frame(
       use e, raw <- let_(e, ir.TermOp(ir.TupleGet(idx), [ir.Var("_frame")]))
       case state.lexical_is_boxed(e, info, ref) {
         False -> {
-          let name = state.slot_var_name(slot)
+          let name = state.slot_var_name(e, slot)
           use body <- state.map_tree(next(state.set_slot_var(e, slot, name)))
           ir.Let([name], ir.Values([raw]), body)
         }
         True -> {
           use e, cell <- host_(e, "cell_new", [raw])
-          let name = state.slot_var_name(slot)
+          let name = state.slot_var_name(e, slot)
           use body <- state.map_tree(next(state.set_slot_var(e, slot, name)))
           ir.Let([name], ir.Values([cell]), body)
         }
@@ -348,7 +348,7 @@ pub fn binding_prologue(
     |> list.sort(fn(a, b) { int.compare({ a.1 }.slot, { b.1 }.slot) })
   use e, entry, next <- each_(e, bindings, then: k)
   let #(_, b): #(String, Binding) = entry
-  let name = state.slot_var_name(b.slot)
+  let name = state.slot_var_name(e, b.slot)
   let seed = fn(e: Emitter2, init) {
     case b.is_boxed {
       False -> {
@@ -516,13 +516,13 @@ fn bind_one_param(
       let b = fn_scope_binding(e, name)
       case b.is_boxed {
         False -> {
-          let vn = state.slot_var_name(b.slot)
+          let vn = state.slot_var_name(e, b.slot)
           use body <- state.map_tree(k(state.set_slot_var(e, b.slot, vn)))
           ir.Let([vn], ir.Values([raw]), body)
         }
         True -> {
           use e, cell <- host_(e, "cell_new", [raw])
-          let vn = state.slot_var_name(b.slot)
+          let vn = state.slot_var_name(e, b.slot)
           use body <- state.map_tree(k(state.set_slot_var(e, b.slot, vn)))
           ir.Let([vn], ir.Values([cell]), body)
         }
@@ -1547,10 +1547,42 @@ fn simple_param_name(i: Int) -> String {
   "_p" <> int.to_string(i)
 }
 
+/// IR name for positional param `i` of a simple-ABI body: the JS parameter's
+/// own name when it is a plain identifier (so the Erlang reads `Xs`, not
+/// `P0`), else the positional `_p{i}`. `fixed` is the function's parameter
+/// pattern list; both the function signature and the body's binding prologue
+/// derive the name from it, so they agree.
+fn simple_param_ir_name(
+  e: Emitter2,
+  fixed: List(ast.Pattern),
+  i: Int,
+) -> String {
+  case list_at(fixed, i) {
+    Some(ast.IdentifierPattern(name:, ..)) -> {
+      let b = fn_scope_binding(e, name)
+      // The slot's own name; a param seeds its slot with itself so both
+      // sides read the same way. Any second parameter with the same name
+      // (sloppy `function f(a, a)`) shares the slot, so this is safe.
+      state.slot_var_name(e, b.slot)
+    }
+    _ -> simple_param_name(i)
+  }
+}
+
+fn list_at(xs: List(a), i: Int) -> Option(a) {
+  case xs, i {
+    [], _ -> None
+    [x, ..], 0 -> Some(x)
+    [_, ..rest], n -> list_at(rest, n - 1)
+  }
+}
+
 /// IR-param name for the positional `this` in a `_t`-variant simple body.
 pub const simple_this_param = "_this"
 
 fn build_simple_ir_params(
+  e: Emitter2,
+  fixed: List(ast.Pattern),
   i: Int,
   ncap: Int,
   arity: Int,
@@ -1559,10 +1591,10 @@ fn build_simple_ir_params(
   case i < ncap {
     True -> [
       ir.Local(cap_param_name(i), ir.TTerm),
-      ..build_simple_ir_params(i + 1, ncap, arity, needs_this)
+      ..build_simple_ir_params(e, fixed, i + 1, ncap, arity, needs_this)
     ]
     False -> {
-      let ps = build_simple_pos_params(0, arity)
+      let ps = build_simple_pos_params(e, fixed, 0, arity)
       case needs_this {
         True -> [ir.Local(simple_this_param, ir.TTerm), ..ps]
         False -> ps
@@ -1571,11 +1603,16 @@ fn build_simple_ir_params(
   }
 }
 
-fn build_simple_pos_params(i: Int, arity: Int) -> List(ir.Local) {
+fn build_simple_pos_params(
+  e: Emitter2,
+  fixed: List(ast.Pattern),
+  i: Int,
+  arity: Int,
+) -> List(ir.Local) {
   case i < arity {
     True -> [
-      ir.Local(simple_param_name(i), ir.TTerm),
-      ..build_simple_pos_params(i + 1, arity)
+      ir.Local(simple_param_ir_name(e, fixed, i), ir.TTerm),
+      ..build_simple_pos_params(e, fixed, i + 1, arity)
     ]
     False -> []
   }
@@ -1585,6 +1622,7 @@ fn build_simple_pos_params(i: Int, arity: Int) -> List(ir.Local) {
 /// IR-param (mirrors `bind_one_param`'s simple branch — cell_new if boxed).
 fn bind_simple_params(
   e: Emitter2,
+  fixed_all: List(ast.Pattern),
   fixed: List(ast.Pattern),
   i: Int,
   k: fn(Emitter2) -> Result(#(ir.Expr, Emitter2), EmitError),
@@ -1595,10 +1633,13 @@ fn bind_simple_params(
       let assert ast.IdentifierPattern(name:, ..) = p
         as "emit_2core/fn: simple-abi param not IdentifierPattern"
       let b = fn_scope_binding(e, name)
-      let raw = ir.Var(simple_param_name(i))
-      let vn = state.slot_var_name(b.slot)
-      let next = fn(e) { bind_simple_params(e, rest, i + 1, k) }
+      let pn = simple_param_ir_name(e, fixed_all, i)
+      let raw = ir.Var(pn)
+      let vn = state.slot_var_name(e, b.slot)
+      let next = fn(e) { bind_simple_params(e, fixed_all, rest, i + 1, k) }
       case b.is_boxed {
+        // The IR param already carries the slot's name: no alias needed.
+        False if pn == vn -> next(state.set_slot_var(e, b.slot, vn))
         False -> {
           use body <- state.map_tree(next(state.set_slot_var(e, b.slot, vn)))
           ir.Let([vn], ir.Values([raw]), body)
@@ -1650,7 +1691,7 @@ fn emit_simple_body(
   run_rk(e, fn(e, done) {
     use e <- seed_simple_this(e, needs_this, info)
     use e <- binding_prologue(e, e.fn_scope)
-    use e <- bind_simple_params(e, fixed, 0)
+    use e <- bind_simple_params(e, fixed, fixed, 0)
     use e <- hoist_fn_decls(e, stmts)
     use #(tree, ef) <- result.try(e.dispatch.emit_stmts(e, stmts, ret_undef))
     done(ef, tree)
@@ -1874,7 +1915,7 @@ pub fn emit_function_tree(
         capture_vals,
       )
     None -> {
-      let #(fn_name, e) = state.fresh_fn_name(e)
+      let #(fn_name, e) = state.fresh_fn_name(e, js_name)
       let field_init = derive_field_init(shape, e.field_init)
       let #(e_child, save) =
         state.enter_function(
@@ -1952,7 +1993,14 @@ pub fn emit_function_tree(
               e_child,
               ir.Function(
                 name: simple_fn_name,
-                params: build_simple_ir_params(0, ncap, arity, needs_this),
+                params: build_simple_ir_params(
+                  e_child,
+                  fixed,
+                  0,
+                  ncap,
+                  arity,
+                  needs_this,
+                ),
                 result: [ir.TTerm],
                 locals: [],
                 body: sbody,

--- a/aot/src/arc_aot/emit/state.gleam
+++ b/aot/src/arc_aot/emit/state.gleam
@@ -8,9 +8,12 @@ import arc/parser/ast
 import arc_aot/emit/split
 import carder/ir
 import gleam/dict.{type Dict}
+import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/order
 import gleam/set.{type Set}
+import gleam/string
 
 /// Compile-time ir.Value constants for JS sentinel atoms (SPEC §2.3 wire ABI).
 /// Built once by `realm_consts()`; carried on Emitter2 so emit_* sites write
@@ -320,11 +323,15 @@ pub type Emitter2 {
     scope_cursor: List(ScopeId),
     child_fn_cursor: List(ScopeId),
     in_block: Bool,
+    /// JS name for each `#(function scope, slot)`, see `slot_names`.
+    slot_names: Dict(#(ScopeId, Int), String),
     // ── name generation (ir.gleam:419-420 uniqueness) ──
     next_var: Int,
     next_label: Int,
     /// module-monotone — survives enter_function
     next_fn: Int,
+    /// Every function base name minted so far (module-monotone).
+    fn_names: Set(String),
     /// module-monotone tagged-template site counter (§13.2.8.4 cache key)
     next_site: Int,
     module_name: String,
@@ -490,8 +497,134 @@ pub fn fresh_label(e: Emitter2) -> #(String, Emitter2) {
   )
 }
 
-pub fn fresh_fn_name(e: Emitter2) -> #(String, Emitter2) {
-  #("jsf_" <> int_to_string(e.next_fn), Emitter2(..e, next_fn: e.next_fn + 1))
+/// A module-unique base name for a compiled function: the JS function's own
+/// name (`add`), `fn_<n>` when it has none, and `add_2`, `add_3`, ... for a
+/// second `add`. Derived names (`add_s`, `add_t`, `add_c3`, `add__sm`) are
+/// built by appending to the base, so a base is also refused when it would
+/// collide with a derived name of another base, or another base with its own
+/// derived name (JS `foo` and `foo_s`).
+pub fn fresh_fn_name(
+  e: Emitter2,
+  js_name: Option(String),
+) -> #(String, Emitter2) {
+  let base = case option.then(js_name, fn_base) {
+    Some(name) -> name
+    None -> "fn_" <> int_to_string(e.next_fn)
+  }
+  let name = unique_fn_name(base, e.fn_names, 2)
+  #(
+    name,
+    Emitter2(
+      ..e,
+      next_fn: e.next_fn + 1,
+      fn_names: set.insert(e.fn_names, name),
+    ),
+  )
+}
+
+/// A JS identifier as an Erlang-friendly function base: ASCII letters
+/// lowercased, digits and `_` kept, anything else (`$`, Unicode letters,
+/// escapes) becomes `_`. A name that is empty, all underscores, or starts
+/// with a digit is unusable and yields `None` (the caller falls back to
+/// `fn_<n>`); `js_main`/`instantiate`/`module_info` are the module's own
+/// entry points and are pushed aside.
+fn fn_base(js_name: String) -> Option(String) {
+  let name =
+    string.to_graphemes(js_name)
+    |> list.map(fn(g) {
+      case g {
+        "_" -> "_"
+        _ ->
+          case is_ascii_digit(g) || is_ascii_letter(g) {
+            True -> string.lowercase(g)
+            False -> "_"
+          }
+      }
+    })
+    |> string.concat
+  let all_underscores = string.replace(name, "_", "") == ""
+  case name, all_underscores {
+    "", _ -> None
+    _, True -> None
+    "js_main", _ | "instantiate", _ | "module_info", _ -> Some(name <> "_")
+    _, _ ->
+      case string.first(name) {
+        Ok(first) ->
+          case is_ascii_digit(first) {
+            True -> None
+            False -> Some(name)
+          }
+        Error(Nil) -> None
+      }
+  }
+}
+
+fn is_ascii_digit(g: String) -> Bool {
+  case g {
+    "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" -> True
+    _ -> False
+  }
+}
+
+fn is_ascii_letter(g: String) -> Bool {
+  case string.to_utf_codepoints(g) {
+    [cp] -> {
+      let c = string.utf_codepoint_to_int(cp)
+      { c >= 65 && c <= 90 } || { c >= 97 && c <= 122 }
+    }
+    _ -> False
+  }
+}
+
+fn unique_fn_name(base: String, taken: Set(String), n: Int) -> String {
+  case fn_name_free(base, taken) {
+    True -> base
+    False -> {
+      let cand = base <> "_" <> int_to_string(n)
+      case fn_name_free(cand, taken) {
+        True -> cand
+        False -> unique_fn_name(base, taken, n + 1)
+      }
+    }
+  }
+}
+
+fn fn_name_free(cand: String, taken: Set(String)) -> Bool {
+  !set.contains(taken, cand)
+  && !set.contains(taken, cand <> "_s")
+  && !set.contains(taken, cand <> "_t")
+  && !set.contains(taken, cand <> "__sm")
+  && list.all(["_s", "_t", "__sm"], fn(suffix) {
+    case strip_suffix(cand, suffix) {
+      Some(stem) -> !set.contains(taken, stem)
+      None -> True
+    }
+  })
+  && case strip_chunk_suffix(cand) {
+    Some(stem) -> !set.contains(taken, stem)
+    None -> True
+  }
+}
+
+fn strip_suffix(s: String, suffix: String) -> Option(String) {
+  case string.ends_with(s, suffix) {
+    True -> Some(string.drop_end(s, string.length(suffix)))
+    False -> None
+  }
+}
+
+/// `foo_c12` → `foo`.
+fn strip_chunk_suffix(s: String) -> Option(String) {
+  case string.split(s, "_c") {
+    [_, _, ..] -> {
+      let assert Ok(last) = list.last(string.split(s, "_c"))
+      case int.parse(last) {
+        Ok(_) -> Some(string.drop_end(s, string.length(last) + 2))
+        Error(Nil) -> None
+      }
+    }
+    _ -> None
+  }
 }
 
 /// Prepend a lowered ir.Function (split into a tail-call chain when its
@@ -513,10 +646,15 @@ pub fn mark_unsupported(e: Emitter2, feature: String) -> Emitter2 {
   Emitter2(..e, unsupported: [feature, ..e.unsupported])
 }
 
-/// Canonical initial IR var name for scope slot `slot`. The function prologue
-/// Let-binds this name; unboxed re-assignment rebinds via set_slot_var.
-pub fn slot_var_name(slot: Int) -> String {
-  "js_local_" <> int_to_string(slot)
+/// Canonical initial IR var name for scope slot `slot` of the current
+/// function: the JS binding's own name (`n`, `xs`; see `slot_names`), or
+/// `js_local_N` for a slot no binding names. The function prologue Let-binds
+/// this name; unboxed re-assignment rebinds via set_slot_var.
+pub fn slot_var_name(e: Emitter2, slot: Int) -> String {
+  case dict.get(e.slot_names, #(e.fn_scope, slot)) {
+    Ok(name) -> name
+    Error(Nil) -> "js_local_" <> int_to_string(slot)
+  }
 }
 
 /// Current IR var name bound to `slot` — its slot_var_name, or the fresh name
@@ -524,8 +662,88 @@ pub fn slot_var_name(slot: Int) -> String {
 pub fn get_slot_var(e: Emitter2, slot: Int) -> String {
   case dict.get(e.slot_vars, slot) {
     Ok(name) -> name
-    Error(_) -> slot_var_name(slot)
+    Error(_) -> slot_var_name(e, slot)
   }
+}
+
+/// The IR var name for every local binding in the tree, keyed by the owning
+/// function scope and slot. Names are the JS identifiers so the emitted code
+/// reads like the source; the emitter's own names start with `_` (`_t7`,
+/// `_p0`, `_L2`), so a JS name that starts with `_` gets a `u` in front to
+/// stay clear of them, and two bindings of one name in the same frame (sibling
+/// blocks) get `__2`, `__3`, ... which the Erlang printer turns back into a
+/// per-function suffix.
+fn slot_names(tree: ScopeTree) -> Dict(#(ScopeId, Int), String) {
+  // Every binding, grouped by the function frame that owns its slot, in slot
+  // order within the frame so the numbering is stable.
+  let by_frame =
+    dict.fold(tree.scopes, dict.new(), fn(acc, _id, sc) {
+      dict.fold(sc.bindings, acc, fn(acc, js_name, b) {
+        dict.upsert(acc, sc.function_scope, fn(existing) {
+          [#(b.slot, js_name), ..option.unwrap(existing, [])]
+        })
+      })
+    })
+  dict.fold(by_frame, dict.new(), fn(acc, frame, entries) {
+    let sorted =
+      list.sort(entries, fn(a, b) {
+        case int.compare(a.0, b.0) {
+          order.Eq -> string.compare(a.1, b.1)
+          other -> other
+        }
+      })
+    let #(acc, _taken) =
+      list.fold(sorted, #(acc, set.new()), fn(st, entry) {
+        let #(acc, taken) = st
+        let #(slot, js_name) = entry
+        let key = #(frame, slot)
+        case dict.has_key(acc, key) {
+          // A capture re-declares the origin's binding in a child scope;
+          // the first name for the slot wins.
+          True -> #(acc, taken)
+          False -> {
+            let name = unique_name(ir_name(js_name), taken, 2)
+            #(dict.insert(acc, key, name), set.insert(taken, name))
+          }
+        }
+      })
+    acc
+  })
+}
+
+/// A class private name `#x` binds as `priv_x`; a JS name starting with `_`
+/// gets a `u` in front (the emitter's own names all start with `_`).
+fn ir_name(js_name: String) -> String {
+  case js_name {
+    "#" <> rest -> "priv_" <> rest
+    "_" <> _ -> "u" <> js_name
+    _ -> js_name
+  }
+}
+
+/// `fresh_slot_var` appends `_<counter>` for rebinds, so sibling duplicates
+/// use a double underscore (`y__2`) and the two can never coincide.
+fn unique_name(base: String, taken: Set(String), n: Int) -> String {
+  case set.contains(taken, base) {
+    False -> base
+    True -> {
+      let cand = base <> "__" <> int_to_string(n)
+      case set.contains(taken, cand) {
+        False -> cand
+        True -> unique_name(base, taken, n + 1)
+      }
+    }
+  }
+}
+
+/// A fresh IR var for an unboxed re-assignment of `slot`, named after the
+/// slot (`t_12` for `t`) so the Erlang reads `T`, `T2`, `T3` for one JS
+/// variable. Same uniqueness as `fresh_var`: the counter is shared.
+pub fn fresh_slot_var(e: Emitter2, slot: Int) -> #(String, Emitter2) {
+  #(
+    slot_var_name(e, slot) <> "_" <> int_to_string(e.next_var),
+    Emitter2(..e, next_var: e.next_var + 1),
+  )
 }
 
 /// Record `name` as the current IR var for `slot`. M12/M13/M15 call this after
@@ -846,9 +1064,11 @@ pub fn new_emitter(
     scope_cursor: block_child_scopes(tree, root),
     child_fn_cursor: scope.child_function_scopes(tree, root),
     in_block: False,
+    slot_names: slot_names(tree),
     next_var: 0,
     next_label: 0,
     next_fn: 0,
+    fn_names: set.new(),
     next_site: 0,
     module_name:,
     frame_stack: [],

--- a/aot/src/arc_aot/emit/stmt.gleam
+++ b/aot/src/arc_aot/emit/stmt.gleam
@@ -99,8 +99,7 @@ fn frame_carried_walk(
         state.Loop2(ir_break:, ir_continue:, carried:, ..)
           if ir_break == ir_label || ir_continue == ir_label
         -> carried
-        state.Switch2(ir_break:, carried:, ..) if ir_break == ir_label ->
-          carried
+        state.Switch2(ir_break:, carried:, ..) if ir_break == ir_label -> carried
         state.Labeled2(ir_break:, carried:, ..) if ir_break == ir_label ->
           carried
         _ -> frame_carried_walk(rest, ir_label)
@@ -482,7 +481,7 @@ fn store_slot(
     True ->
       host_unit_(e, "cell_set", [ir.Var(state.get_slot_var(e, b.slot)), val], k)
     False -> {
-      let name = state.slot_var_name(b.slot)
+      let name = state.slot_var_name(e, b.slot)
       use body <- state.map_tree(k(state.set_slot_var(e, b.slot, name)))
       ir.Let([name], ir.Values([val]), body)
     }
@@ -503,7 +502,7 @@ fn binding_prologue(
     |> list.sort(fn(a, b) { int.compare({ a.1 }.slot, { b.1 }.slot) })
   use e, entry, next <- each_(e, bindings, then: k)
   let #(_, b): #(String, Binding) = entry
-  let name = state.slot_var_name(b.slot)
+  let name = state.slot_var_name(e, b.slot)
   let seed = fn(e: Emitter2, init) {
     case b.is_boxed {
       False -> {
@@ -747,7 +746,7 @@ fn store_declared(
         True ->
           host_unit_(e, "cell_set", [ir.Var(state.get_slot_var(e, slot)), v], k)
         False -> {
-          let #(n, e) = state.fresh_var(e)
+          let #(n, e) = state.fresh_slot_var(e, slot)
           // Propagate known-number through the alias so a for-init `let i=0`
           // seed carries the mark.
           let e = case v {
@@ -854,7 +853,7 @@ fn carried_params(
   let #(e, params) = {
     use #(e, acc), slot <- list.fold(slots, #(e, []))
     let init = ir.Var(state.get_slot_var(e, slot))
-    let #(name, e) = state.fresh_var(e)
+    let #(name, e) = state.fresh_slot_var(e, slot)
     #(e, [ir.LoopParam(name:, ty: ir.TTerm, init:), ..acc])
   }
   #(list.reverse(params), e)
@@ -889,7 +888,7 @@ fn rebind_after_block(
 ) -> Result(#(ir.Expr, Emitter2), EmitError) {
   let #(e, names) = {
     use #(e, names), slot <- list.fold(slots, #(e, []))
-    let #(n, e) = state.fresh_var(e)
+    let #(n, e) = state.fresh_slot_var(e, slot)
     #(state.set_slot_var(e, slot, n), [n, ..names])
   }
   let names = list.reverse(names)
@@ -1662,7 +1661,7 @@ fn for_lhs_ident_assign(
               k,
             )
           False -> {
-            let #(n, e) = state.fresh_var(e)
+            let #(n, e) = state.fresh_slot_var(e, slot)
             use body <- state.map_tree(k(state.set_slot_var(e, slot, n)))
             ir.Let([n], ir.Values([v]), body)
           }
@@ -2489,7 +2488,7 @@ fn per_iter_rebox(
       let old = ir.Var(state.get_slot_var(e, slot))
       use e, v <- host_(e, "cell_get", [old])
       use e, cell <- host_(e, "cell_new", [v])
-      let #(n, e) = state.fresh_var(e)
+      let #(n, e) = state.fresh_slot_var(e, slot)
       use body <- state.map_tree(next(state.set_slot_var(e, slot, n)))
       ir.Let([n], ir.Values([cell]), body)
     }

--- a/src/arc/compiler/scope.gleam
+++ b/src/arc/compiler/scope.gleam
@@ -522,10 +522,7 @@ pub type RawFunctionInfo {
 }
 
 /// Default `RawFunctionInfo` — non-arrow, no Annex-B candidates yet.
-const blank_raw_fn_info = RawFunctionInfo(
-  is_arrow: False,
-  annexb_candidates: [],
-)
+const blank_raw_fn_info = RawFunctionInfo(is_arrow: False, annexb_candidates: [])
 
 /// A fresh `RawScope` with the 8 always-default fields filled in. The 5
 /// per-site fields (id / parent / function_scope / kind / is_strict) are

--- a/src/arc/link.gleam
+++ b/src/arc/link.gleam
@@ -244,8 +244,7 @@ fn resolve_local_export(
         case binding {
           esm.NamedImport(local:, ..) if local == local_name ->
             Ok(#(dep, binding))
-          esm.DefaultImport(local:) if local == local_name ->
-            Ok(#(dep, binding))
+          esm.DefaultImport(local:) if local == local_name -> Ok(#(dep, binding))
           esm.NamespaceImport(local:, ..) if local == local_name ->
             Ok(#(dep, binding))
           _ -> Error(Nil)

--- a/src/arc/parser/lexer.gleam
+++ b/src/arc/parser/lexer.gleam
@@ -494,8 +494,7 @@ fn skip_line_inner(rest: BitArray, n: Int) -> Int {
     <<0xE2, 0x80, 0xA8, _:bytes>> -> n
     <<0xE2, 0x80, 0xA9, _:bytes>> -> n
     <<b, tail:bytes>> if b < 0x80 -> skip_line_inner(tail, n + 1)
-    <<b, _, tail:bytes>> if b >= 0xC0 && b < 0xE0 ->
-      skip_line_inner(tail, n + 2)
+    <<b, _, tail:bytes>> if b >= 0xC0 && b < 0xE0 -> skip_line_inner(tail, n + 2)
     <<b, _, _, tail:bytes>> if b >= 0xE0 && b < 0xF0 ->
       skip_line_inner(tail, n + 3)
     <<b, _, _, _, tail:bytes>> if b >= 0xF0 && b < 0xF8 ->

--- a/src/arc/rt/async.gleam
+++ b/src/arc/rt/async.gleam
@@ -605,8 +605,7 @@ pub fn generator_data(st: Agent, this: JsVal) -> Handle {
 fn read_generator(st: Agent, gen_h: Handle) -> JsSlot {
   case rt_store.t_cell_get(st, gen_h) {
     SGenerator(..) as gen -> gen
-    _ ->
-      panic as "rt_async: Handle is not an SGenerator cell (engine invariant)"
+    _ -> panic as "rt_async: Handle is not an SGenerator cell (engine invariant)"
   }
 }
 

--- a/src/arc/rt/val.gleam
+++ b/src/arc/rt/val.gleam
@@ -1068,8 +1068,7 @@ pub fn t_to_numeric(st: Agent, v: JsVal) -> #(JsVal, Agent) {
     KNull -> #(mk_number(JInt(0)), st)
     KUndef -> #(mk_number(JNan), st)
     KSym(_) -> t_throw_type_error(st, "Cannot convert Symbol to number")
-    KHandle(_) | KTdz ->
-      panic as "ToNumeric: ToPrimitive returned non-primitive"
+    KHandle(_) | KTdz -> panic as "ToNumeric: ToPrimitive returned non-primitive"
   }
 }
 

--- a/test/interp_exceptions_test.gleam
+++ b/test/interp_exceptions_test.gleam
@@ -73,9 +73,7 @@ fn thrown(source: String) -> String {
   case run(source) {
     #(ThrowCompletion(e), st) -> rt_inspect.inspect(st, e)
     #(NormalCompletion(v), st) ->
-      panic as {
-        source <> " did not throw, gave " <> rt_inspect.inspect(st, v)
-      }
+      panic as { source <> " did not throw, gave " <> rt_inspect.inspect(st, v) }
   }
 }
 


### PR DESCRIPTION
Pairs with scarletindustries/carder#92 (this branch pins that commit). Together they make the emitted Erlang read like the JavaScript it came from, without changing what is emitted.

The AOT emitter named IR variables `_p0` / `js_local_4` / `_t7` and functions `jsf_0` / `jsf_0_s`. Now:

- a JS binding's IR variable is its own name (`n`, `xs`; a `#priv` field is `priv_x`, a JS name starting with `_` gets a `u` in front so it stays clear of the emitter's own `_t`/`_p`/`_L` names, and two bindings of one name in one frame get `__2`, `__3`) — `state.slot_names`, computed once from the scope tree
- an unboxed re-assignment of a slot rebinds as `<name>_<n>` (`state.fresh_slot_var`), so one JS variable reads as `T`, `T2`, `T3` in the Erlang instead of `V48`
- a simple-ABI function's positional params carry the JS parameter names, and the alias `Let` is skipped when it would be `let a = a`
- a compiled function is named after the JS function (`add`, `add_s`; `fn_<n>` when anonymous or the name is unusable; `add_2` on a clash), with the derived `_s`/`_t`/`_c<n>`/`__sm` names checked against the module-wide set so no base can coincide with another's derived name

`function greet(name) { return "hi " + name }`, before and after:

```erlang
jsf_1_s(V0, V1) ->                                greet_s(St, Name) ->
    V2 = <<"hi ">>,                                   Const = <<"hi ">>,
    {V7, V8} =                                        {St3, T34} =
        case is_integer(V2) andalso is_integer(V1) of     case is_integer(Const) andalso is_integer(Name) of
            true ->                                           true ->
                V3 = V2 + V1,                                     T27 = Const + Name,
                ...                                               ...
            false ->                                          false ->
                {V5, V6} = arc_rt_ops_ffi:t_add(V0, V2, V1),      {T33, St2} = arc_rt_ops_ffi:t_add(St, Const, Name),
                {V6, V5}                                          {St2, T33}
        end,                                              end,
    {V8, V7}.                                         {T34, St3}.
```

Verification: aot 100/100, arc 1861/1861, the four Octane programs run, full AOT test262 exec has no regressions against master (the three annexB failures it reports are also on master with the current carder pin), Octane probe within noise (richards 8808 vs 8668, deltablue 20137 vs 20263, crypto 145994 vs 148983, raytrace 95365 vs 96040 µs/iter). Compiled react-dom/server: same 1765 atoms, function instruction streams identical modulo labels/names/register choice.