### PR TITLE
known strings and to_boolean

### DIFF
--- a/aot/gleam.toml
+++ b/aot/gleam.toml
@@ -4,7 +4,7 @@ target = "erlang"
 
 [dependencies]
 arc = { path = ".." }
-carder = { git = "https://github.com/scarletindustries/carder", ref = "7ac066a6c4544724bfe09a5a038c411b968a98cb" }
+carder = { git = "https://github.com/scarletindustries/carder", ref = "0dad1611fc12284cdb389e06843fdee1c6dba963" }
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleam_erlang = ">= 1.0.0 and < 2.0.0"
 argv = ">= 1.0.0 and < 2.0.0"

--- a/aot/manifest.toml
+++ b/aot/manifest.toml
@@ -9,7 +9,7 @@
 packages = [
   { name = "arc", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "simplifile"], source = "local", path = ".." },
   { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
-  { name = "carder", version = "1.0.0", build_tools = ["gleam"], requirements = ["argv", "gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "https://github.com/scarletindustries/carder", commit = "7ac066a6c4544724bfe09a5a038c411b968a98cb" },
+  { name = "carder", version = "1.0.0", build_tools = ["gleam"], requirements = ["argv", "gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "https://github.com/scarletindustries/carder", commit = "0dad1611fc12284cdb389e06843fdee1c6dba963" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
@@ -20,7 +20,7 @@ packages = [
 [requirements]
 arc = { path = ".." }
 argv = { version = ">= 1.0.0 and < 2.0.0" }
-carder = { git = "https://github.com/scarletindustries/carder", ref = "7ac066a6c4544724bfe09a5a038c411b968a98cb" }
+carder = { git = "https://github.com/scarletindustries/carder", ref = "0dad1611fc12284cdb389e06843fdee1c6dba963" }
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }

--- a/aot/src/arc_aot/emit/anf.gleam
+++ b/aot/src/arc_aot/emit/anf.gleam
@@ -79,6 +79,27 @@ pub fn is_known_number(e: Emitter2, v: ir.Value) -> Bool {
   }
 }
 
+/// Record an existing `ir.Var` as a known JS string and yield it unchanged.
+pub fn mark_string(v: ir.Value) -> Build(ir.Value) {
+  fn(e, k) {
+    case v {
+      ir.Var(name) -> k(state.mark_known_string(e, name), v)
+      _ -> k(e, v)
+    }
+  }
+}
+
+/// True iff `v` is a string literal or a var recorded via `mark_string`. Such
+/// an operand can never be a BEAM number, so an arithmetic or relational op
+/// on it skips the integer fast path.
+pub fn is_known_string(e: Emitter2, v: ir.Value) -> Bool {
+  case v {
+    ir.Var(name) -> state.is_known_string(e, name)
+    ir.ConstBinary(_) -> True
+    _ -> False
+  }
+}
+
 /// Bind a `js` host call. D2: NO St arg — emit_core M9 injects instance state.
 /// Invariant #3: this is the ONLY CallHost("js", ..) constructor in emit_2core/*.
 pub fn host(op: String, args: List(ir.Value)) -> Build(ir.Value) {
@@ -537,9 +558,17 @@ pub fn guarded_binop(
   b: ir.Value,
 ) -> Build(ir.Value) {
   fn(e, k) {
-    case is_known_number(e, a) && is_known_number(e, b) {
-      True -> num_binop(fast_op, a, b)(e, k)
-      False ->
+    let string_side = is_known_string(e, a) || is_known_string(e, b)
+    case is_known_number(e, a) && is_known_number(e, b), string_side {
+      True, _ -> num_binop(fast_op, a, b)(e, k)
+      // A string operand can never take the integer arm; `+` on it is a
+      // concatenation, whose result is a string too.
+      False, True ->
+        case fast_op {
+          "num_add" -> then(host(slow_op <> "_any", [a, b]), mark_string)(e, k)
+          _ -> host(slow_op <> "_any", [a, b])(e, k)
+        }
+      False, False ->
         int_or(
           fast_op,
           a,
@@ -554,6 +583,21 @@ pub fn guarded_binop(
 /// JS relational `< <= > >= ==`: as `guarded_binop` but the fast arm's
 /// NumTerm yields TI32 (gotcha #4), so it is re-branched to a JS bool atom.
 pub fn guarded_cmp(
+  fast: ir.NumTermOp,
+  slow_op: String,
+  a: ir.Value,
+  b: ir.Value,
+) -> Build(ir.Value) {
+  fn(e, k) {
+    case is_known_string(e, a) || is_known_string(e, b) {
+      // A string operand never takes the numeric arm.
+      True -> then(host(slow_op, [a, b]), i32_to_js_bool)(e, k)
+      False -> guarded_cmp_numeric(fast, slow_op, a, b)(e, k)
+    }
+  }
+}
+
+fn guarded_cmp_numeric(
   fast: ir.NumTermOp,
   slow_op: String,
   a: ir.Value,
@@ -597,6 +641,20 @@ pub fn i32_to_js_bool(v: ir.Value) -> Build(ir.Value) {
 /// `ir.If` cond (loop conditions) — skips the bool-atom wrap + `truthy` unwrap
 /// that `guarded_cmp` incurs. Slow arm coerces the JS bool result to i32.
 pub fn cond_cmp(
+  fast: ir.NumTermOp,
+  slow_op: String,
+  a: ir.Value,
+  b: ir.Value,
+) -> Build(ir.Value) {
+  fn(e, k) {
+    case is_known_string(e, a) || is_known_string(e, b) {
+      True -> then(host(slow_op, [a, b]), fn(v) { host("truthy", [v]) })(e, k)
+      False -> cond_cmp_numeric(fast, slow_op, a, b)(e, k)
+    }
+  }
+}
+
+fn cond_cmp_numeric(
   fast: ir.NumTermOp,
   slow_op: String,
   a: ir.Value,

--- a/aot/src/arc_aot/emit/expr.gleam
+++ b/aot/src/arc_aot/emit/expr.gleam
@@ -571,10 +571,16 @@ fn expr_operand(ex: ast.Expression) -> Build(ir.Value) {
   }
 }
 
+/// `v == null` as i32: `v =:= undefined orelse v =:= null`. Emitted as an
+/// If rather than an i32 add so the backend can spell it as the `orelse`.
 fn nul_eq_inline(v: ir.Value) -> Build(ir.Value) {
   use u <- anf.then(anf.bind(ir.NumTerm(ir.NEq, v, ir.ConstAtom("undefined"))))
-  use n <- anf.then(anf.bind(ir.NumTerm(ir.NEq, v, ir.ConstAtom("null"))))
-  anf.bind(ir.NumTerm(ir.NAdd, u, n))
+  anf.bind(ir.If(
+    u,
+    [ir.TI32],
+    ir.Values([ir.ConstI32(1)]),
+    ir.NumTerm(ir.NEq, v, ir.ConstAtom("null")),
+  ))
 }
 
 // ── const-global folding (perf-gate-richards) ───────────────────────────────

--- a/aot/src/arc_aot/emit/state.gleam
+++ b/aot/src/arc_aot/emit/state.gleam
@@ -371,6 +371,10 @@ pub type Emitter2 {
     /// Seeded by anf.bind_number/mark_number; read by anf.guarded_binop/cmp
     /// to elide `is_number` TermTests on the M0 sum hot path.
     known_numbers: Set(String),
+    /// IR vars known to hold a JS string (a `+` with a string operand, a
+    /// template literal, `typeof`); a `+`/`<` with one never takes the
+    /// integer fast path.
+    known_strings: Set(String),
     /// Unboxed-local slot → pre-computed `kfn_code` pair var, hoisted before a
     /// loop so calls in the body reuse it. Per-function; cleared on enter.
     hoisted_kfn: Dict(Int, ir.Value),
@@ -409,6 +413,14 @@ pub fn mark_known_number(e: Emitter2, name: String) -> Emitter2 {
 
 pub fn is_known_number(e: Emitter2, name: String) -> Bool {
   set.contains(e.known_numbers, name)
+}
+
+pub fn mark_known_string(e: Emitter2, name: String) -> Emitter2 {
+  Emitter2(..e, known_strings: set.insert(e.known_strings, name))
+}
+
+pub fn is_known_string(e: Emitter2, name: String) -> Bool {
+  set.contains(e.known_strings, name)
 }
 
 pub fn set_const_globals(e: Emitter2, d: Dict(String, ir.Value)) -> Emitter2 {
@@ -1088,6 +1100,7 @@ pub fn new_emitter(
     slot_vars: dict.new(),
     initialized: set.new(),
     known_numbers: set.new(),
+    known_strings: set.new(),
     hoisted_kfn: dict.new(),
     const_globals: dict.new(),
     slotted_globals: dict.new(),

--- a/src/arc_rt_val_ffi.erl
+++ b/src/arc_rt_val_ffi.erl
@@ -26,7 +26,7 @@
     classify/1,
     mk_undefined/0, mk_hole/0, mk_null/0, mk_bool/1, mk_number/1, mk_int/1,
     mk_string/1, mk_bigint/1, mk_symbol/1, mk_object/1, mk_tdz/0,
-    to_boolean_i32/1,
+    to_boolean_i32/1, to_boolean/1,
     t_to_property_key_fast/1,
     js_number_to_string/1,
     parse_float/1,
@@ -58,6 +58,27 @@ classify({js_bigint, N}) -> {k_big, N};
 classify({js_sym, S}) -> {k_sym, S};
 classify({js_cell, N}) -> {k_handle, {js_cell, N}};
 classify(js_tdz) -> k_tdz.
+
+%% to_boolean(JsVal) -> boolean()
+%% ToBoolean as an Erlang boolean, for compiled code that tests it with a
+%% `case ... of false/true`. Same rows as to_boolean_i32/1.
+to_boolean(undefined) -> false;
+to_boolean(null) -> false;
+to_boolean(false) -> false;
+to_boolean(true) -> true;
+to_boolean(0) -> false;
+to_boolean(N) when is_integer(N) -> true;
+to_boolean(F) when is_float(F) -> F /= 0.0;
+to_boolean(js_nan) -> false;
+to_boolean(js_inf) -> true;
+to_boolean(js_neg_inf) -> true;
+to_boolean(<<>>) -> false;
+to_boolean(B) when is_binary(B) -> true;
+to_boolean({js_bigint, 0}) -> false;
+to_boolean({js_bigint, _}) -> true;
+to_boolean({js_sym, _}) -> true;
+to_boolean({js_cell, _}) -> true;
+to_boolean(js_tdz) -> false.
 
 %% to_boolean_i32(JsVal) -> 0 | 1
 %% ES2024 §7.1.2 ToBoolean as an i32 for direct use as an ir.If cond.


### PR DESCRIPTION
Pairs with scarletindustries/carder#93 (pinned). The emitter side of the "smaller Erlang" layer.

- `arc_rt_val_ffi:to_boolean/1`, ToBoolean as an Erlang boolean, row for row the same as `to_boolean_i32/1`. carder's printer rewrites `case to_boolean_i32(V) of 0 -> ...` into `case to_boolean(V) of false -> ...`.
- The emitter tracks IR variables known to hold a JS string (`state.known_strings`, alongside `known_numbers`): a string literal operand, the result of `+` with a string operand, and so on. `+`/`-`/`*` and `<`/`<=`/`>`/`>=` on a known string skip the integer fast path and go straight to the runtime op, since that operand can never be a BEAM number. `"hi " + name` used to be a `case is_integer(<<"hi ">>) andalso is_integer(Name) of` ladder; it is now

  ```erlang
  greet_s(St, Name) ->
      arc_rt_ops_ffi:t_add(St, <<"hi ">>, Name).
  ```
- `x == null` / `x != null` lower to an `If` instead of an i32 add of two comparisons, so the backend prints `X =:= undefined orelse X =:= null`.

Verification: aot 100/100, arc 1861/1861, the four Octane programs run, AOT test262 `language/` 21117 pass (was 21048; the only "regressions" are the three annexB failures already on master), Octane probe equal or faster (richards 8697 vs 8668, deltablue 19918 vs 20263, crypto 146337 vs 148983, raytrace 94864 vs 96040 µs/iter). fuller's regenerated react-dom/server module: 6/6 tests, 20 ms per render as before.