### PR TITLE
name capture params

### DIFF
--- a/aot/gleam.toml
+++ b/aot/gleam.toml
@@ -4,7 +4,7 @@ target = "erlang"
 
 [dependencies]
 arc = { path = ".." }
-carder = { git = "https://github.com/scarletindustries/carder", ref = "0dad1611fc12284cdb389e06843fdee1c6dba963" }
+carder = { git = "https://github.com/scarletindustries/carder", ref = "7928eb9242a9eb2acf9b93038f8d163bd196d0ec" }
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleam_erlang = ">= 1.0.0 and < 2.0.0"
 argv = ">= 1.0.0 and < 2.0.0"

--- a/aot/manifest.toml
+++ b/aot/manifest.toml
@@ -9,7 +9,7 @@
 packages = [
   { name = "arc", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "simplifile"], source = "local", path = ".." },
   { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
-  { name = "carder", version = "1.0.0", build_tools = ["gleam"], requirements = ["argv", "gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "https://github.com/scarletindustries/carder", commit = "0dad1611fc12284cdb389e06843fdee1c6dba963" },
+  { name = "carder", version = "1.0.0", build_tools = ["gleam"], requirements = ["argv", "gleam_erlang", "gleam_stdlib", "simplifile"], source = "git", repo = "https://github.com/scarletindustries/carder", commit = "7928eb9242a9eb2acf9b93038f8d163bd196d0ec" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_stdlib", version = "1.0.5", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CEE5B6C076A85B45F60C585F4316C63EC8B7127C119D5738C3958A9C4D50404E" },
@@ -20,7 +20,7 @@ packages = [
 [requirements]
 arc = { path = ".." }
 argv = { version = ">= 1.0.0 and < 2.0.0" }
-carder = { git = "https://github.com/scarletindustries/carder", ref = "0dad1611fc12284cdb389e06843fdee1c6dba963" }
+carder = { git = "https://github.com/scarletindustries/carder", ref = "7928eb9242a9eb2acf9b93038f8d163bd196d0ec" }
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }

--- a/aot/src/arc_aot/emit/async.gleam
+++ b/aot/src/arc_aot/emit/async.gleam
@@ -2787,20 +2787,20 @@ fn sm_default_arm(e: Emitter2) -> #(ir.Expr, Emitter2) {
 
 // ── §18.1 state-machine ir.Function shell (u-sm-skeleton-emit) ──────────────
 
-/// D13: local copy of func.gleam:226 `cap_param_name` — do NOT import
-/// func.gleam. Must stay byte-identical so the outer `jsf_N` and this
-/// `jsf_N__sm` closure agree on capture-param positions.
-fn cap_param_name(i: Int) -> String {
-  "cap_" <> int.to_string(i)
+/// The outer function and its state machine share one capture list, so both
+/// name capture param `i` through `state.cap_param_name` on an emitter that
+/// carries the same `cap_names` (the sm's emitter copies the outer's).
+fn cap_param_name(e: Emitter2, i: Int) -> String {
+  state.cap_param_name(e, i)
 }
 
 /// Build the sm function's ir param list: `[cap_0..cap_{ncap-1}, _rs, _sent,
 /// _loc]` (SPEC §18.1 / M8 wire ABI). Mirrors func.gleam:284-288 shape.
-fn build_sm_params(i: Int, ncap: Int) -> List(ir.Local) {
+fn build_sm_params(e: Emitter2, i: Int, ncap: Int) -> List(ir.Local) {
   case i < ncap {
     True -> [
-      ir.Local(cap_param_name(i), ir.TTerm),
-      ..build_sm_params(i + 1, ncap)
+      ir.Local(cap_param_name(e, i), ir.TTerm),
+      ..build_sm_params(e, i + 1, ncap)
     ]
     False -> [
       ir.Local("_rs", ir.TTerm),
@@ -2864,7 +2864,7 @@ fn emit_sm_function(
     e,
     ir.Function(
       name: sm_name,
-      params: build_sm_params(0, ncap),
+      params: build_sm_params(e, 0, ncap),
       result: [ir.TTerm],
       locals: [],
       body: body,
@@ -2876,21 +2876,21 @@ fn emit_sm_function(
 
 /// D5 uniform IR-param shape: [cap_0.., _frame, _args]. Local copy of
 /// func.gleam:284-288 (D13: no cross-emit-module imports).
-fn build_outer_params(i: Int, n: Int) -> List(ir.Local) {
+fn build_outer_params(e: Emitter2, i: Int, n: Int) -> List(ir.Local) {
   case i < n {
     False -> [ir.Local("_frame", ir.TTerm), ir.Local("_args", ir.TTerm)]
     True -> [
-      ir.Local(cap_param_name(i), ir.TTerm),
-      ..build_outer_params(i + 1, n)
+      ir.Local(cap_param_name(e, i), ir.TTerm),
+      ..build_outer_params(e, i + 1, n)
     ]
   }
 }
 
 /// The outer's own cap-param Values, forwarded verbatim as sm's captures.
-fn cap_vars(i: Int, n: Int) -> List(ir.Value) {
+fn cap_vars(e: Emitter2, i: Int, n: Int) -> List(ir.Value) {
   case i < n {
     False -> []
-    True -> [ir.Var(cap_param_name(i)), ..cap_vars(i + 1, n)]
+    True -> [ir.Var(cap_param_name(e, i)), ..cap_vars(e, i + 1, n)]
   }
 }
 
@@ -4583,9 +4583,10 @@ pub fn emit_coroutine_fn(
   let ncap = list.length(captures)
   let stmts = func.body_stmts(body)
   let is_strict = e.strict || ast_util.has_use_strict_directive(stmts)
-  let #(sm_base, e) = state.fresh_fn_name(e, js_name)
-  let sm_name = sm_base <> "__sm"
+  // The outer function takes the JS name; its state machine is `<name>__sm`
+  // (a derived name, reserved with the base by `fresh_fn_name`).
   let #(outer_name, e) = state.fresh_fn_name(e, js_name)
+  let sm_name = outer_name <> "__sm"
   let enter = fn(e) {
     state.enter_function(
       e,
@@ -4626,6 +4627,8 @@ pub fn emit_coroutine_fn(
     // frame so `fns_acc`/`next_var` keep threading; its cursor and the set
     // of bindings already initialized are the post-prologue ones.
     let #(e_sm, sm_save) = enter(e_pro)
+    // The state machine takes the same captures as the outer function.
+    let e_sm = state.Emitter2(..e_sm, cap_names: e_pro.cap_names)
     let e_sm =
       state.Emitter2(
         ..install_cursor(e_sm, cur0),
@@ -4646,7 +4649,7 @@ pub fn emit_coroutine_fn(
             anf.make_tuple(initial_loc_values(e_pro, layout, info.local_count)),
           )
           use sm <- anf.then(
-            anf.bind(ir.MakeClosure(sm_name, cap_vars(0, ncap), 3)),
+            anf.bind(ir.MakeClosure(sm_name, cap_vars(e_pro, 0, ncap), 3)),
           )
           anf.host(start_op(kind), [
             sm,
@@ -4683,7 +4686,7 @@ pub fn emit_coroutine_fn(
       e_outer,
       ir.Function(
         name: outer_name,
-        params: build_outer_params(0, ncap),
+        params: build_outer_params(e_outer, 0, ncap),
         result: [ir.TTerm],
         locals: [],
         body: body_expr,

--- a/aot/src/arc_aot/emit/class.gleam
+++ b/aot/src/arc_aot/emit/class.gleam
@@ -814,7 +814,7 @@ fn build_class_init_closure(
       e_child,
       ir.Function(
         name: fn_name,
-        params: func.build_ir_params(0, ncap),
+        params: func.build_ir_params(e_child, 0, ncap),
         result: [ir.TTerm],
         locals: [],
         body: body_expr,

--- a/aot/src/arc_aot/emit/func.gleam
+++ b/aot/src/arc_aot/emit/func.gleam
@@ -214,8 +214,8 @@ fn derive_field_init(
 // ── captures (SPEC §3.1; compiler.gleam:595-622 canonical order) ────────────
 
 /// IR-param name for the i'th capture (D5: precedes `_frame`/`_args`).
-pub fn cap_param_name(i: Int) -> String {
-  "cap_" <> int.to_string(i)
+pub fn cap_param_name(e: Emitter2, i: Int) -> String {
+  state.cap_param_name(e, i)
 }
 
 fn capture_count(info: FunctionInfo) -> Int {
@@ -251,32 +251,45 @@ pub fn build_capture_values(
 /// Seed slot_vars in the CHILD frame so reads of a captured name resolve to
 /// the corresponding cap_i IR-param.
 pub fn seed_capture_slots(e: Emitter2, info: FunctionInfo) -> Emitter2 {
-  let #(e, i) =
-    list.fold(info.captures, #(e, 0), fn(acc, c) {
-      let #(e, i) = acc
+  // Name each capture param after the binding it carries: the JS name for
+  // a variable capture (unique in this frame like every slot name), a fixed
+  // name for a lexical one. Recorded on the emitter first so the same names
+  // reach the function's param list.
+  let names =
+    list.map(info.captures, fn(c) {
       let assert Ok(child_slot) = dict.get(info.names, c.0)
         as "emit_2core/fn: capture name missing from FunctionInfo.names"
-      #(state.set_slot_var(e, child_slot, cap_param_name(i)), i + 1)
+      #(child_slot, state.slot_var_name(e, child_slot))
     })
-  let #(e, _) =
-    list.fold(lexical.all_lexical_refs, #(e, i), fn(acc, ref) {
-      let #(e, i) = acc
+  let lexical_names =
+    list.filter_map(lexical.all_lexical_refs, fn(ref) {
       case dict.get(info.lexical_captures, ref) {
-        Ok(child_slot) -> #(
-          state.set_slot_var(e, child_slot, cap_param_name(i)),
-          i + 1,
-        )
-        Error(_) -> #(e, i)
+        Ok(child_slot) -> Ok(#(child_slot, lexical_capture_name(ref)))
+        Error(Nil) -> Error(Nil)
       }
     })
-  e
+  let all = list.append(names, lexical_names)
+  let e = Emitter2(..e, cap_names: list.map(all, fn(p) { p.1 }))
+  list.fold(all, e, fn(e, p) { state.set_slot_var(e, p.0, p.1) })
+}
+
+fn lexical_capture_name(ref: lexical.LexicalRef) -> String {
+  case ref {
+    lexical.RefThis -> "this_cap"
+    lexical.RefActiveFunc -> "func_cap"
+    lexical.RefHomeObject -> "home_cap"
+    lexical.RefNewTarget -> "new_target_cap"
+  }
 }
 
 /// D5 uniform IR-param shape: `[cap_0.., _frame, _args]`.
-pub fn build_ir_params(i: Int, n: Int) -> List(ir.Local) {
+pub fn build_ir_params(e: Emitter2, i: Int, n: Int) -> List(ir.Local) {
   case i < n {
     False -> [ir.Local("_frame", ir.TTerm), ir.Local("_args", ir.TTerm)]
-    True -> [ir.Local(cap_param_name(i), ir.TTerm), ..build_ir_params(i + 1, n)]
+    True -> [
+      ir.Local(cap_param_name(e, i), ir.TTerm),
+      ..build_ir_params(e, i + 1, n)
+    ]
   }
 }
 
@@ -1590,7 +1603,7 @@ fn build_simple_ir_params(
 ) -> List(ir.Local) {
   case i < ncap {
     True -> [
-      ir.Local(cap_param_name(i), ir.TTerm),
+      ir.Local(cap_param_name(e, i), ir.TTerm),
       ..build_simple_ir_params(e, fixed, i + 1, ncap, arity, needs_this)
     ]
     False -> {
@@ -1705,6 +1718,7 @@ fn emit_simple_body(
 /// the list ends early the remaining params are `undefined`, extras are
 /// dropped. No allocation, one branch per param.
 fn simple_shim_body(
+  e: Emitter2,
   target: String,
   ncap: Int,
   arity: Int,
@@ -1712,7 +1726,7 @@ fn simple_shim_body(
   undef: ir.Value,
 ) -> ir.Expr {
   let caps =
-    build_ir_params(0, ncap)
+    build_ir_params(e, 0, ncap)
     |> list.take(ncap)
     |> list.map(fn(l) { ir.Var(l.name) })
   let this = case needs_this {
@@ -1968,7 +1982,7 @@ pub fn emit_function_tree(
               e_child,
               ir.Function(
                 name: fn_name,
-                params: build_ir_params(0, ncap),
+                params: build_ir_params(e_child, 0, ncap),
                 result: [ir.TTerm],
                 locals: [],
                 body: body_expr,
@@ -2011,10 +2025,11 @@ pub fn emit_function_tree(
               e_child,
               ir.Function(
                 name: fn_name,
-                params: build_ir_params(0, ncap),
+                params: build_ir_params(e_child, 0, ncap),
                 result: [ir.TTerm],
                 locals: [],
                 body: simple_shim_body(
+                  e_child,
                   simple_fn_name,
                   ncap,
                   arity,

--- a/aot/src/arc_aot/emit/state.gleam
+++ b/aot/src/arc_aot/emit/state.gleam
@@ -136,6 +136,7 @@ pub type FnSave {
     class_stack: List(ClassCtx),
     // per-function slot mapping (slot indices are function-scope-local)
     slot_vars: Dict(Int, String),
+    cap_names: List(String),
     initialized: Set(Int),
     hoisted_kfn: Dict(Int, ir.Value),
     // M18: nested non-coroutine fn must NOT inherit the parent's SM intercept
@@ -325,6 +326,9 @@ pub type Emitter2 {
     in_block: Bool,
     /// JS name for each `#(function scope, slot)`, see `slot_names`.
     slot_names: Dict(#(ScopeId, Int), String),
+    /// IR names of the current function's capture params, in capture order
+    /// (`func.seed_capture_slots` sets it; the param builders read it).
+    cap_names: List(String),
     // ── name generation (ir.gleam:419-420 uniqueness) ──
     next_var: Int,
     next_label: Int,
@@ -758,6 +762,24 @@ pub fn fresh_slot_var(e: Emitter2, slot: Int) -> #(String, Emitter2) {
   )
 }
 
+/// IR name of capture param `i` of the current function: the captured JS
+/// binding's own name (set by `func.seed_capture_slots`), or `cap_<i>` when
+/// no name is recorded for that position.
+pub fn cap_param_name(e: Emitter2, i: Int) -> String {
+  case list_at(e.cap_names, i) {
+    Some(name) -> name
+    None -> "cap_" <> int_to_string(i)
+  }
+}
+
+fn list_at(xs: List(a), i: Int) -> Option(a) {
+  case xs, i {
+    [], _ -> None
+    [x, ..], 0 -> Some(x)
+    [_, ..rest], n -> list_at(rest, n - 1)
+  }
+}
+
 /// Record `name` as the current IR var for `slot`. M12/M13/M15 call this after
 /// every unboxed Let-rebind so later Identifier reads see the new SSA name.
 pub fn set_slot_var(e: Emitter2, slot: Int, name: String) -> Emitter2 {
@@ -1077,6 +1099,7 @@ pub fn new_emitter(
     child_fn_cursor: scope.child_function_scopes(tree, root),
     in_block: False,
     slot_names: slot_names(tree),
+    cap_names: [],
     next_var: 0,
     next_label: 0,
     next_fn: 0,
@@ -1303,6 +1326,7 @@ pub fn enter_function(
       this_tdz: e.this_tdz,
       class_stack: e.class_stack,
       slot_vars: e.slot_vars,
+      cap_names: e.cap_names,
       initialized: e.initialized,
       hoisted_kfn: e.hoisted_kfn,
       sm_abrupt: e.sm_abrupt,
@@ -1330,6 +1354,7 @@ pub fn enter_function(
       this_tdz: is_arrow && e.this_tdz,
       class_stack: e.class_stack,
       slot_vars: dict.new(),
+      cap_names: [],
       initialized: set.new(),
       hoisted_kfn: dict.new(),
       sm_abrupt: None,
@@ -1362,6 +1387,7 @@ pub fn leave_function(e: Emitter2, save: FnSave) -> Emitter2 {
     this_tdz: save.this_tdz,
     class_stack: save.class_stack,
     slot_vars: save.slot_vars,
+    cap_names: save.cap_names,
     initialized: save.initialized,
     hoisted_kfn: save.hoisted_kfn,
     sm_abrupt: save.sm_abrupt,


### PR DESCRIPTION
Closure capture parameters were `cap_0`, `cap_1`, ... They now carry the captured JS binding's own name, so a closure reads `fn_1_s(St, N, Step)` instead of `fn_1_s(St, Cap, Cap2)`; a lexical capture is `this_cap` / `func_cap` / `home_cap` / `new_target_cap`.

`func.seed_capture_slots` computes the names once per function (the JS name from `slot_names`, unique in the frame like every slot) and records them on the emitter (`Emitter2.cap_names`, saved and reset with the other per-function fields); the parameter builders in func/class/async read them through `state.cap_param_name`, and the async state machine copies the outer function's list so both agree.

An async function is now named for its JS name with the state machine derived from it (`later` / `later__sm`) instead of the outer being pushed to `later_2`.

Also pins carder at main's merge commit (same code as the #93 commit it pointed at).

aot 100/100, arc 1861/1861, the four Octane programs run, AOT test262 `language/` unchanged (21117 pass, the three annexB failures are on master).